### PR TITLE
feat(dataset-runs): add dataset run get/list/delete lifecycle methods

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1075,6 +1075,66 @@ create_dataset_run_item(dataset_item_id:, run_name:, trace_id: nil,
 
 **Returns:** `Hash` (created dataset run item data)
 
+### `Client#get_dataset_run`
+
+Fetch a dataset run and its linked run items.
+
+**Signature:**
+
+```ruby
+get_dataset_run(dataset_name:, run_name:) # => Hash
+```
+
+**Parameters:**
+
+| Parameter      | Type   | Required | Description  |
+| -------------- | ------ | -------- | ------------ |
+| `dataset_name` | String | Yes      | Dataset name |
+| `run_name`     | String | Yes      | Run name     |
+
+**Returns:** `Hash`
+
+### `Client#list_dataset_runs`
+
+List runs for a dataset. Auto-paginates when `page` is omitted.
+
+**Signature:**
+
+```ruby
+list_dataset_runs(dataset_name:, page: nil, limit: nil) # => Array<Hash>
+```
+
+**Parameters:**
+
+| Parameter      | Type    | Required | Description                                |
+| -------------- | ------- | -------- | ------------------------------------------ |
+| `dataset_name` | String  | Yes      | Dataset name                               |
+| `page`         | Integer | No       | Page number (nil = fetch all pages)        |
+| `limit`        | Integer | No       | Results per page                           |
+
+**Returns:** `Array<Hash>`
+
+### `Client#delete_dataset_run`
+
+Delete a dataset run by dataset and run name.
+
+**Signature:**
+
+```ruby
+delete_dataset_run(dataset_name:, run_name:) # => nil
+```
+
+Unlike `delete_dataset_item`, this is strict: a missing run raises `Langfuse::NotFoundError`.
+
+**Parameters:**
+
+| Parameter      | Type   | Required | Description  |
+| -------------- | ------ | -------- | ------------ |
+| `dataset_name` | String | Yes      | Dataset name |
+| `run_name`     | String | Yes      | Run name     |
+
+**Returns:** `nil`
+
 See [DATASETS.md](DATASETS.md) for complete guide.
 
 ## Experiments

--- a/docs/DATASETS.md
+++ b/docs/DATASETS.md
@@ -193,6 +193,38 @@ end
 
 The block receives a traced span. On completion (or error), the trace is flushed and the item is linked automatically.
 
+## Managing Dataset Runs
+
+Dataset runs are created when you link items into a named run, either manually or through experiments. Once a run exists, you can fetch it, list all runs for a dataset, or delete it by dataset name and run name.
+
+```ruby
+# Fetch a single run with its linked run items
+run = client.get_dataset_run(
+  dataset_name: "qa-eval",
+  run_name: "qa-v2"
+)
+
+run["id"]              # => "run-123"
+run["datasetRunItems"] # => [...]
+
+# List all runs for a dataset (auto-paginates)
+runs = client.list_dataset_runs(dataset_name: "qa-eval")
+
+# Fetch a single page only
+runs = client.list_dataset_runs(dataset_name: "qa-eval", page: 2, limit: 20)
+
+# Delete a run by name
+client.delete_dataset_run(dataset_name: "qa-eval", run_name: "qa-v2")
+```
+
+| Method                     | Behavior |
+| -------------------------- | -------- |
+| `get_dataset_run`          | Fetch one run and its linked run items |
+| `list_dataset_runs`        | Returns `Array<Hash>` of runs; auto-paginates unless `page:` is provided |
+| `delete_dataset_run`       | Deletes a run by dataset and run name |
+
+Unlike `delete_dataset_item`, deleting a missing dataset run is not idempotent in this SDK. A missing run raises `Langfuse::NotFoundError` to match the upstream API behavior.
+
 ## See Also
 
 - [EXPERIMENTS.md](EXPERIMENTS.md) - Run systematic evaluations against datasets

--- a/lib/langfuse/client.rb
+++ b/lib/langfuse/client.rb
@@ -701,17 +701,9 @@ module Langfuse
     end
 
     def fetch_all_dataset_items(limit:, **filters)
-      per_page = limit || DATASET_ITEMS_PAGE_SIZE
-      first_result = api_client.list_dataset_items_paginated(page: 1, limit: per_page, **filters)
-      items = first_result["data"] || []
-      total_pages = first_result.dig("meta", "totalPages") || 1
-
-      (2..total_pages).each do |pg|
-        result = api_client.list_dataset_items_paginated(page: pg, limit: per_page, **filters)
-        items.concat(result["data"] || [])
+      fetch_all_paginated_data(limit: limit) do |page:, per_page:|
+        api_client.list_dataset_items_paginated(page: page, limit: per_page, **filters)
       end
-
-      items
     end
 
     def fetch_dataset_runs_page(dataset_name:, page:, limit:)
@@ -719,17 +711,25 @@ module Langfuse
     end
 
     def fetch_all_dataset_runs(dataset_name:, limit:)
-      per_page = limit || DATASET_ITEMS_PAGE_SIZE
-      first_result = api_client.list_dataset_runs_paginated(dataset_name: dataset_name, page: 1, limit: per_page)
-      runs = first_result["data"] || []
+      fetch_all_paginated_data(limit: limit) do |page:, per_page:|
+        api_client.list_dataset_runs_paginated(dataset_name: dataset_name, page: page, limit: per_page)
+      end
+    end
+
+    # Keep dataset collection pagination semantics in one place so edge cases
+    # like missing or zero totalPages stay consistent across APIs.
+    def fetch_all_paginated_data(limit:)
+      page_size = limit || DATASET_ITEMS_PAGE_SIZE
+      first_result = yield(page: 1, per_page: page_size)
+      records = first_result["data"] || []
       total_pages = first_result.dig("meta", "totalPages") || 1
 
-      (2..total_pages).each do |pg|
-        result = api_client.list_dataset_runs_paginated(dataset_name: dataset_name, page: pg, limit: per_page)
-        runs.concat(result["data"] || [])
+      (2..total_pages).each do |page|
+        result = yield(page: page, per_page: page_size)
+        records.concat(result["data"] || [])
       end
 
-      runs
+      records
     end
 
     def resolve_experiment_items(data, dataset_name)

--- a/spec/langfuse/api_client_spec.rb
+++ b/spec/langfuse/api_client_spec.rb
@@ -2445,6 +2445,27 @@ RSpec.describe Langfuse::ApiClient do
       end
     end
 
+    context "with dataset names requiring encoding" do
+      let(:dataset_name) { "folder name/with spaces" }
+
+      before do
+        stub_request(:get, "#{base_url}/api/public/datasets/folder%20name%2Fwith%20spaces/runs")
+          .to_return(
+            status: 200,
+            body: runs_response.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "encodes dataset name in request path" do
+        api_client.list_dataset_runs(dataset_name: dataset_name)
+
+        expect(
+          a_request(:get, "#{base_url}/api/public/datasets/folder%20name%2Fwith%20spaces/runs")
+        ).to have_been_made.once
+      end
+    end
+
     context "when network error occurs" do
       before do
         stub_request(:get, "#{base_url}/api/public/datasets/my-dataset/runs")


### PR DESCRIPTION
Supersedes #56 after branch rename to conventional format.

#### `TL;DR`
<!-- One sentence -->

#### `Why`
<!-- Motivation/context for this change -->

#### `Checklist`
- [ ] Has label
- [ ] Has linked issue
- [ ] Tests added for new behavior
- [ ] Docs updated (if user-facing)

Closes #

## Summary
- Added dataset run lifecycle APIs to `ApiClient`: `get_dataset_run`, `list_dataset_runs`, `list_dataset_runs_paginated`, and `delete_dataset_run`.
- Added flat `Client` wrappers for dataset run lifecycle operations with auto-pagination behavior matching dataset items.
- Added URL encoding for dataset/run names in dataset-run paths (supports spaces and slashes).
- Enforced strict delete semantics for missing dataset runs (`404` raises `NotFoundError`).
- Added API/client specs for get/list/delete dataset runs, pagination, encoding, and strict 404 behavior.
- Tests/validation:
  - `bundle exec rspec` (1168 examples, 0 failures, 98.08% coverage)
  - `bundle exec rubocop` (no offenses)
  - Langfuse CLI schema/action validation via `$langfuse` skill (`datasets get-get-run/get-get-runs/delete`) including generated encoded REST paths

## Architecture (Core Change)
- Mermaid not applicable (flat API surface extension without new component interactions).
