### PR TITLE
Let users correlate external IDs with traces

### DIFF
--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -387,6 +387,7 @@ module Langfuse
     #   obs = Langfuse.observe("operation", input: { data: "test" })
     #   obs.update(output: { result: "success" })
     #   obs.end
+    # rubocop:disable Metrics/MethodLength
     def observe(name, attrs = {}, as_type: :span, trace_id: nil, **kwargs, &block)
       # Merge positional attrs and keyword kwargs
       merged_attrs = attrs.to_h.merge(kwargs)
@@ -403,13 +404,16 @@ module Langfuse
         # Block-based API: auto-ends when block completes
         # Set context and execute block
         current_context = OpenTelemetry::Context.current
-        result = OpenTelemetry::Context.with_current(
-          OpenTelemetry::Trace.context_with_span(observation.otel_span, parent_context: current_context)
-        ) do
-          block.call(observation)
+        begin
+          result = OpenTelemetry::Context.with_current(
+            OpenTelemetry::Trace.context_with_span(observation.otel_span, parent_context: current_context)
+          ) do
+            block.call(observation)
+          end
+        ensure
+          # Only end if not already ended (events auto-end in start_observation)
+          observation.end unless as_type.to_s == OBSERVATION_TYPES[:event]
         end
-        # Only end if not already ended (events auto-end in start_observation)
-        observation.end unless as_type.to_s == OBSERVATION_TYPES[:event]
         result
       else
         # Stateful API - return observation
@@ -417,6 +421,7 @@ module Langfuse
         observation
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     # Registry mapping observation type strings to their wrapper classes
     OBSERVATION_TYPE_REGISTRY = {

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -370,10 +370,12 @@ module Langfuse
     # @param name [String] Descriptive name for the observation
     # @param attrs [Hash] Observation attributes (optional positional or keyword)
     # @param as_type [Symbol, String] Observation type (:span, :generation, :event, etc.)
+    # @param trace_id [String, nil] Trace ID for connecting to an existing trace (32 lowercase hex char string)
     # @param kwargs [Hash] Additional keyword arguments merged into observation attributes (e.g., input:, output:, metadata:)
     # @yield [observation] Optional block that receives the observation object
     # @yieldparam observation [BaseObservation] The observation object
     # @return [BaseObservation, Object] The observation (or block return value if block given)
+    # @raise [ArgumentError] if an invalid trace ID is provided
     #
     # @example Block-based API (auto-ends)
     #   Langfuse.observe("operation") do |obs|
@@ -385,10 +387,17 @@ module Langfuse
     #   obs = Langfuse.observe("operation", input: { data: "test" })
     #   obs.update(output: { result: "success" })
     #   obs.end
-    def observe(name, attrs = {}, as_type: :span, **kwargs, &block)
+    def observe(name, attrs = {}, as_type: :span, trace_id: nil, **kwargs, &block)
       # Merge positional attrs and keyword kwargs
       merged_attrs = attrs.to_h.merge(kwargs)
-      observation = start_observation(name, merged_attrs, as_type: as_type)
+      unless trace_id.nil?
+        unless valid_trace_id?(trace_id)
+          raise ArgumentError, "#{trace_id} is not a valid 32 lowercase hex char Langfuse trace ID"
+        end
+
+        parent_span_context = create_span_context_with_trace_id(trace_id)
+      end
+      observation = start_observation(name, merged_attrs, as_type: as_type, parent_span_context: parent_span_context)
 
       if block
         # Block-based API: auto-ends when block completes
@@ -485,6 +494,33 @@ module Langfuse
     def wrap_otel_span(otel_span, type_str, otel_tracer, attributes: nil)
       observation_class = OBSERVATION_TYPE_REGISTRY[type_str] || Span
       observation_class.new(otel_span, otel_tracer, attributes: attributes)
+    end
+
+    # Validates that a trace ID is valid
+    #
+    # @param trace_id [String] The trace ID to validate
+    # @return [Boolean] true if valid, false otherwise
+    #
+    # @example
+    #   valid_trace_id?("my-trace-id")                      # => false
+    #   valid_trace_id?("1234567890abcdef1234567890abcdef") # => true
+    def valid_trace_id?(trace_id)
+      !!(trace_id =~ /^[0-9a-f]{32}$/)
+    end
+
+    # Creates a span context with an explicit trace ID
+    #
+    # @param trace_id_as_hex_str [String] A valid trace ID
+    # @return [OpenTelemetry::Trace::SpanContext] The new span context
+    def create_span_context_with_trace_id(trace_id_as_hex_str)
+      trace_id_as_byte_str = [trace_id_as_hex_str].pack("H*")
+      # NOTE: trace_flags must be SAMPLED or the trace will not appear in Langfuse.
+      # The Python SDK does the same: https://github.com/langfuse/langfuse-python/blob/v4.0.0/langfuse/_client/client.py#L1568
+      trace_flags = OpenTelemetry::Trace::TraceFlags::SAMPLED
+      OpenTelemetry::Trace::SpanContext.new(
+        trace_id: trace_id_as_byte_str,
+        trace_flags: trace_flags
+      )
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -416,5 +416,18 @@ RSpec.describe Langfuse do
         end.to raise_error(ArgumentError, /Invalid observation type/)
       end
     end
+
+    context "with trace ID" do
+      it "raises ArgumentError for invalid trace ID" do
+        expect do
+          described_class.observe("test", trace_id: "test-trace-id")
+        end.to raise_error(ArgumentError, /not a valid/)
+      end
+
+      it "creates observation with given trace ID" do
+        result = described_class.observe("test", trace_id: "1234567890abcdef1234567890abcdef", &:trace_id)
+        expect(result).to eq("1234567890abcdef1234567890abcdef")
+      end
+    end
   end
 end

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -372,6 +372,20 @@ RSpec.describe Langfuse do
       # We can't directly check if the observation was ended, but the block should have executed
     end
 
+    it "auto-ends observation even if block raises error" do
+      observation = instance_double(Langfuse::BaseObservation)
+      expect(observation).to receive(:otel_span)
+      expect(observation).to receive(:end)
+
+      allow(described_class).to receive(:start_observation).and_return(observation)
+
+      expect do
+        described_class.observe("test") do |_obs|
+          raise "error"
+        end
+      end.to raise_error("error")
+    end
+
     it "auto-ends events even without block" do
       observation = described_class.observe("test-event", {}, as_type: :event)
       expect(observation).to be_a(Langfuse::Event)


### PR DESCRIPTION
#### `TL;DR`
This change lets users set a deterministic trace ID when creating an observation.

#### `Why`
Langfuse may be used with an application having no reference to trace IDs. The application should be able to create trace IDs based on the IDs of its own models, so that it can, for example, add scores to existing traces.

See also https://langfuse.com/docs/observability/features/trace-ids-and-distributed-tracing

#### `Checklist`
- [ ] Has label
- [ ] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)