### PR TITLE
[ML-931] docs: align docs with implementation

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -149,7 +149,7 @@ get_prompt(name, version: nil, label: nil, fallback: nil, type: nil)
 | `name`     | String  | Yes         | Prompt name                                          |
 | `version`  | Integer | No          | Specific version (mutually exclusive with `label`)   |
 | `label`    | String  | No          | Version label (e.g., "production")                   |
-| `fallback` | String  | No          | Fallback template if not found                       |
+| `fallback` | String, Array<Hash> | No | Fallback prompt if not found (String for text, Array<Hash> for chat) |
 | `type`     | Symbol  | Conditional | `:text` or `:chat` (required if `fallback` provided) |
 
 **Returns:** `TextPromptClient` or `ChatPromptClient`
@@ -163,7 +163,7 @@ get_prompt(name, version: nil, label: nil, fallback: nil, type: nil)
 **Examples:**
 
 ```ruby
-# Latest version
+# API default selection
 prompt = client.get_prompt("greeting")
 
 # Specific version

--- a/docs/CACHING.md
+++ b/docs/CACHING.md
@@ -564,7 +564,7 @@ config.cache_stale_while_revalidate = !Rails.env.development?
 
 # Production: enabled for best performance
 if Rails.env.production?
-  config.cache_stale_ttl = config.cache_ttl  # Auto-set, but can customize
+  config.cache_stale_ttl = config.cache_ttl  # Set explicitly (common default)
 end
 ```
 

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -183,13 +183,13 @@ prompt = client.get_prompt("greeting", label: "production")  # => version 3
 
 ### Best Practices
 
-1. **Default to production:** Omitting `version`/`label` fetches the `production`-labeled prompt (matching JS/Python SDK behavior)
-2. **Use labels in production:** Pin to `production` label for stability
+1. **Be explicit in production:** Use `label: "production"` for deterministic prompt selection
+2. **Treat implicit selection as API-defined:** If you omit `version` and `label`, selection behavior is determined by the Langfuse API
 3. **Version for rollback:** Keep version numbers for emergency rollbacks
 
 ```ruby
 # Development
-prompt = client.get_prompt("greeting")  # Latest version
+prompt = client.get_prompt("greeting")  # Uses Langfuse API default selection
 
 # Production
 prompt = client.get_prompt("greeting", label: "production")  # Stable


### PR DESCRIPTION
#### `TL;DR`
<!-- One sentence -->

#### `Why`
<!-- Motivation/context for this change -->

#### `Checklist`
- [ ] Has label
- [ ] Has linked issue
- [ ] Tests added for new behavior
- [ ] Docs updated (if user-facing)

Closes #

## Summary
- Align docs with implementation for prompt fallback typing and SWR configuration guidance.
- Remove ambiguous default-selection wording and make explicit production-label guidance clearer.

## Fixes Addressed
- `docs/CACHING.md`: removed incorrect "auto-set" wording for `cache_stale_ttl`.
- `docs/API_REFERENCE.md`: corrected `get_prompt` `fallback` type to include chat fallback arrays.
- `docs/PROMPTS.md`: clarified unlabeled selection as API-defined and explicit-label best practice.

## Validation Checklist
- [x] Langfuse CLI capability check (`npx langfuse-cli api __schema`)
- [x] Langfuse prompts get contract check (`npx langfuse-cli api prompts get --help`)
- [ ] `bundle exec rspec` (blocked locally: Bundler executable mismatch)
- [ ] `bundle exec rubocop` (blocked locally: Bundler executable mismatch)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simplepractice/langfuse-rb/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
