### PR TITLE
[ML-964] Custom/deterministic trace ID support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Custom/deterministic trace ID support via `Langfuse.create_trace_id(seed:)` (#74)
-- `trace_id:` keyword on `Langfuse.observe` and `Langfuse.start_observation` for attaching observations to a specific trace
-- Cross-SDK deterministic IDs: same seed produces the same trace ID in Ruby, Python, and JS SDKs (SHA-256 based)
-- PII safety warnings in YARD docs for seed parameters
-
-### Changed
-- **BREAKING:** `create_trace_id(seed:)` now raises `ArgumentError` for non-String seeds (previously coerced via `.to_s`). This ensures cross-SDK parity since Python/JS reject non-strings.
-- `Langfuse::TraceId.valid?` and `Langfuse::TraceId.to_span_context` are now private (internal API only)
-
-### Removed
-- `Langfuse.create_observation_id` and `Langfuse::TraceId.create_observation_id` (no consumer; Python's equivalent is also private)
-- `Langfuse::TraceId.valid_observation_id?` (no callers)
-
-### Fixed
-- Block exceptions in `observe`/`start_observation` now reliably end the span via `ensure`, even when `span.end` itself raises (#74)
-- Reject all-zero trace IDs per W3C trace-context spec (#74)
-
 ## [0.6.0] - 2026-03-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Custom/deterministic trace ID support via `Langfuse.create_trace_id(seed:)` (#74)
+- `trace_id:` keyword on `Langfuse.observe` and `Langfuse.start_observation` for attaching observations to a specific trace
+- Cross-SDK deterministic IDs: same seed produces the same trace ID in Ruby, Python, and JS SDKs (SHA-256 based)
+- PII safety warnings in YARD docs for seed parameters
+
+### Changed
+- **BREAKING:** `create_trace_id(seed:)` now raises `ArgumentError` for non-String seeds (previously coerced via `.to_s`). This ensures cross-SDK parity since Python/JS reject non-strings.
+- `Langfuse::TraceId.valid?` and `Langfuse::TraceId.to_span_context` are now private (internal API only)
+
+### Removed
+- `Langfuse.create_observation_id` and `Langfuse::TraceId.create_observation_id` (no consumer; Python's equivalent is also private)
+- `Langfuse::TraceId.valid_observation_id?` (no callers)
+
+### Fixed
+- Block exceptions in `observe`/`start_observation` now reliably end the span via `ensure`, even when `span.end` itself raises (#74)
+- Reject all-zero trace IDs per W3C trace-context spec (#74)
+
 ## [0.6.0] - 2026-03-06
 
 ### Added

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -7,6 +7,7 @@ Complete method reference for the Langfuse Ruby SDK.
 - [Global Configuration](#global-configuration)
 - [Client Access](#client-access)
 - [Prompt Management](#prompt-management)
+- [Trace ID Generation](#trace-id-generation)
 - [Tracing & Observability](#tracing--observability)
 - [Traces](#traces)
 - [Scoring](#scoring)
@@ -403,6 +404,46 @@ messages = prompt.compile(topic: "Ruby", level: "beginner")
 # ]
 ```
 
+## Trace ID Generation
+
+### `Langfuse.create_trace_id`
+
+Generate a deterministic or random trace ID.
+
+**Signature:**
+
+```ruby
+create_trace_id(seed: nil) # => String
+```
+
+**Parameters:**
+
+| Parameter | Type   | Required | Default | Description                                                                 |
+| --------- | ------ | -------- | ------- | --------------------------------------------------------------------------- |
+| `seed`    | String | No       | `nil`   | Deterministic seed. Same seed → same ID across Ruby, Python, JS SDKs.      |
+
+**Returns:** 32-character lowercase hex trace ID
+
+**Raises:** `ArgumentError` if seed is not nil and not a String
+
+**Example:**
+
+```ruby
+# Random
+trace_id = Langfuse.create_trace_id
+# => "a7f2b3c4d5e6f7a8b9c0d1e2f3a4b5c6"
+
+# Deterministic from seed
+trace_id = Langfuse.create_trace_id(seed: "order-42")
+# => "3bf8b157c4238eefe5ae4a66eca81c6b"
+
+# Cross-SDK: same result in Python and JS
+# Python: Langfuse.create_trace_id(seed="order-42")
+# JS:     await createTraceId("order-42")
+```
+
+See [TRACING.md](TRACING.md#custom-trace-ids) for usage patterns.
+
 ## Tracing & Observability
 
 ### `Langfuse.observe`
@@ -413,10 +454,10 @@ Create a traced observation (block or stateful mode).
 
 ```ruby
 # Block mode (auto-ends)
-observe(name, attributes = {}, as_type: :span) { |obs| ... }
+observe(name, attributes = {}, as_type: :span, trace_id: nil) { |obs| ... }
 
 # Stateful mode (manual end)
-observe(name, attributes = {}, as_type: :span) # => BaseObservation
+observe(name, attributes = {}, as_type: :span, trace_id: nil) # => BaseObservation
 ```
 
 **Parameters:**
@@ -426,6 +467,7 @@ observe(name, attributes = {}, as_type: :span) # => BaseObservation
 | `name`       | String | Yes      | -       | Operation name     |
 | `attributes` | Hash   | No       | `{}`    | Initial attributes |
 | `as_type`    | Symbol | No       | `:span` | Observation type   |
+| `trace_id`   | String | No       | `nil`   | Custom trace ID (32 lowercase hex chars). Use `Langfuse.create_trace_id(seed:)` to generate. |
 
 **Observation Types:**
 
@@ -454,6 +496,41 @@ obs.end
 ```
 
 See [TRACING.md](TRACING.md) for complete guide.
+
+### `Langfuse.start_observation`
+
+Low-level factory for creating observations. Prefer `Langfuse.observe` for most use cases.
+
+**Signature:**
+
+```ruby
+start_observation(name, attrs = {}, as_type: :span, trace_id: nil,
+                  parent_span_context: nil, start_time: nil)
+```
+
+**Parameters:**
+
+| Parameter              | Type         | Required | Default | Description                                                                 |
+| ---------------------- | ------------ | -------- | ------- | --------------------------------------------------------------------------- |
+| `name`                 | String       | Yes      | -       | Operation name                                                              |
+| `attrs`                | Hash         | No       | `{}`    | Initial attributes                                                          |
+| `as_type`              | Symbol       | No       | `:span` | Observation type                                                            |
+| `trace_id`             | String       | No       | `nil`   | Custom trace ID (32 lowercase hex chars). Mutually exclusive with `parent_span_context`. |
+| `parent_span_context`  | SpanContext  | No       | `nil`   | Parent span context for child observations                                  |
+| `start_time`           | Time/Integer | No       | `nil`   | Custom start time                                                           |
+
+**Returns:** `BaseObservation` (Span, Generation, Event, etc.)
+
+**Raises:** `ArgumentError` if both `trace_id` and `parent_span_context` provided, or if `trace_id` is invalid
+
+**Example:**
+
+```ruby
+trace_id = Langfuse.create_trace_id(seed: "order-42")
+obs = Langfuse.start_observation("process", { input: "data" }, trace_id: trace_id)
+obs.update(output: { result: "done" })
+obs.end
+```
 
 ### `BaseObservation`
 

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -392,7 +392,33 @@ end
 
 ### Store for Later Scoring
 
-Common pattern: Store trace ID with user interaction for async scoring:
+#### Recommended: Deterministic Trace IDs
+
+Use `Langfuse.create_trace_id(seed:)` to derive the trace ID from a stable external identifier. No database column needed — any code that knows the external ID can recompute the trace ID:
+
+```ruby
+# During request — derive trace_id from order ID
+trace_id = Langfuse.create_trace_id(seed: "order-#{order.id}")
+
+Langfuse.observe("process-order", trace_id: trace_id) do |obs|
+  result = process_request(order)
+  obs.update(output: result)
+end
+
+# Later (background job, different service) — recompute, don't look up
+trace_id = Langfuse.create_trace_id(seed: "order-#{order.id}")
+
+Langfuse.create_score(
+  name: "quality",
+  value: evaluate(order),
+  trace_id: trace_id,
+  data_type: :numeric
+)
+```
+
+#### Alternative: Store the Trace ID
+
+If you don't have a stable external identifier, capture and persist the trace ID:
 
 ```ruby
 # During request

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -10,6 +10,7 @@ For basic setup and quick start examples, see [GETTING_STARTED.md](GETTING_START
 - [Quick Examples](#quick-examples)
 - [Complete Examples](#complete-examples)
 - [Best Practices](#best-practices)
+- [Custom Trace IDs](#custom-trace-ids)
 - [Advanced Usage](#advanced-usage)
 - [Masking](#masking)
 
@@ -493,6 +494,119 @@ end
 Langfuse.observe("operation") do |span|
   span.update_trace(user_id: "user-123", session_id: "session-456")
   # Only this span has the attributes, not children created before this call
+end
+```
+
+## Custom Trace IDs
+
+By default, Langfuse generates random trace IDs. Custom trace IDs let you control the trace identity — useful when you need to reference a trace later from a different part of your system.
+
+### When to Use Custom Trace IDs
+
+- **Background job scoring** — a web request creates a trace, a worker scores it hours later
+- **Cross-service correlation** — multiple services contribute to the same logical trace
+- **Idempotent retries** — reprocessing the same input lands on the same trace
+- **External ID correlation** — link Langfuse traces to your database rows without storing trace IDs
+
+### Deterministic Trace IDs from Seeds
+
+Generate the same trace ID from the same seed, every time, across Ruby, Python, and JS SDKs:
+
+```ruby
+trace_id = Langfuse.create_trace_id(seed: "order-42")
+# => "3bf8b157c4238eefe5ae4a66eca81c6b"
+
+# Same seed, same ID — even from a different process
+trace_id_again = Langfuse.create_trace_id(seed: "order-42")
+# => "3bf8b157c4238eefe5ae4a66eca81c6b"
+```
+
+Under the hood: `SHA-256(seed)[0..15]` → 32-char lowercase hex. This matches the Python SDK's `Langfuse.create_trace_id(seed=...)` and the JS SDK's `createTraceId(seed)`.
+
+> [!IMPORTANT]
+> Seeds must be **String** values. Passing non-String types (integers, symbols) raises `ArgumentError`. This ensures cross-SDK parity — Python and JS also reject non-strings.
+
+> [!WARNING]
+> Do not pass PII, secrets, or credentials as seeds. The seed itself appears in your application code and may leak through logs and backtraces. Use stable, non-sensitive identifiers: database primary keys, UUIDs, or request IDs.
+
+### Using Custom Trace IDs
+
+Pass `trace_id:` to `observe` or `start_observation`:
+
+```ruby
+trace_id = Langfuse.create_trace_id(seed: "order-42")
+
+# Block-based
+Langfuse.observe("process-order", trace_id: trace_id) do |span|
+  span.update_trace(user_id: "user-123", tags: ["orders"])
+  result = process_order(42)
+  span.update(output: result)
+end
+
+# Stateful
+obs = Langfuse.observe("process-order", trace_id: trace_id)
+obs.update(output: { status: "done" })
+obs.end
+```
+
+You can also use a pre-generated hex trace ID directly (must be 32 lowercase hex characters):
+
+```ruby
+# ✅ Good — valid 32-char lowercase hex
+Langfuse.observe("op", trace_id: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4") { ... }
+
+# ❌ Bad — not valid hex format
+Langfuse.observe("op", trace_id: "my-custom-id") { ... }
+# => ArgumentError: Invalid trace_id
+```
+
+### Complete Example: Web Request + Background Scoring
+
+```ruby
+# === Web server ===
+class OrdersController < ApplicationController
+  def create
+    order = Order.create!(params)
+
+    # Deterministic trace ID from order's primary key
+    trace_id = Langfuse.create_trace_id(seed: "order-#{order.id}")
+
+    Langfuse.observe("process-order", trace_id: trace_id) do |span|
+      span.update_trace(user_id: current_user.id, tags: ["orders"])
+
+      span.start_observation("validate", input: order.attributes) do |child|
+        child.update(output: { valid: true })
+      end
+
+      span.start_observation("llm-summarize", as_type: :generation) do |gen|
+        gen.model = "gpt-4"
+        gen.input = [{ role: "user", content: "Summarize: #{order.description}" }]
+        summary = call_llm(gen.input)
+        gen.update(output: summary, usage_details: { input: 50, output: 20 })
+      end
+    end
+
+    # No need to store trace_id — it can be recomputed from order.id
+    render json: order
+  end
+end
+
+# === Background worker (hours later) ===
+class OrderQualityJob
+  def perform(order_id)
+    # Recompute the same trace ID — no database lookup needed
+    trace_id = Langfuse.create_trace_id(seed: "order-#{order_id}")
+
+    score = evaluate_order_quality(order_id)
+
+    Langfuse.create_score(
+      name: "order_quality",
+      value: score,
+      trace_id: trace_id,
+      data_type: :numeric,
+      comment: "Async quality evaluation"
+    )
+  end
 end
 ```
 

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -344,11 +344,14 @@ module Langfuse
     # @param name [String] Descriptive name for the observation
     # @param attrs [Hash, Types::SpanAttributes, Types::GenerationAttributes, nil] Observation attributes
     # @param as_type [Symbol, String] Observation type (:span, :generation, :event, etc.)
+    # @param trace_id [String, nil] Optional 32-char lowercase hex trace ID to attach the observation to.
+    #   Mutually exclusive with `parent_span_context`. Use {Langfuse.create_trace_id} to generate one.
     # @param parent_span_context [OpenTelemetry::Trace::SpanContext, nil] Parent span context for child observations
     # @param start_time [Time, Integer, nil] Optional start time (Time object or Unix timestamp in nanoseconds)
     # @param skip_validation [Boolean] Skip validation (for internal use). Defaults to false.
     # @return [BaseObservation] The observation wrapper (Span, Generation, or Event)
-    # @raise [ArgumentError] if an invalid observation type is provided
+    # @raise [ArgumentError] if an invalid observation type is provided, an invalid `trace_id` is given,
+    #   or both `trace_id` and `parent_span_context` are provided
     #
     # @example Create root span
     #   span = Langfuse.start_observation("root-operation", { input: {...} })
@@ -389,10 +392,13 @@ module Langfuse
     # @param name [String] Descriptive name for the observation
     # @param attrs [Hash] Observation attributes (optional positional or keyword)
     # @param as_type [Symbol, String] Observation type (:span, :generation, :event, etc.)
+    # @param trace_id [String, nil] Optional 32-char lowercase hex trace ID to attach the observation to.
+    #   Use {Langfuse.create_trace_id} to generate one. Forwarded to {.start_observation}.
     # @param kwargs [Hash] Additional keyword arguments merged into observation attributes (e.g., input:, output:, metadata:)
     # @yield [observation] Optional block that receives the observation object
     # @yieldparam observation [BaseObservation] The observation object
     # @return [BaseObservation, Object] The observation (or block return value if block given)
+    # @raise [ArgumentError] if an invalid `trace_id` is provided
     #
     # @example Block-based API (auto-ends)
     #   Langfuse.observe("operation") do |obs|
@@ -412,22 +418,6 @@ module Langfuse
       run_in_observation_context(observation, as_type, &block)
     end
 
-    # Runs `block` with `observation` as the current OTel span and ends the
-    # span in `ensure` so block exceptions don't leak unfinished spans.
-    # Events are skipped because they auto-end at creation.
-    #
-    # @api private
-    def run_in_observation_context(observation, as_type, &block)
-      current_context = OpenTelemetry::Context.current
-      OpenTelemetry::Context.with_current(
-        OpenTelemetry::Trace.context_with_span(observation.otel_span, parent_context: current_context)
-      ) do
-        block.call(observation)
-      end
-    ensure
-      observation.end unless as_type.to_s == OBSERVATION_TYPES[:event]
-    end
-
     # Registry mapping observation type strings to their wrapper classes
     OBSERVATION_TYPE_REGISTRY = {
       OBSERVATION_TYPES[:generation] => Generation,
@@ -443,6 +433,25 @@ module Langfuse
     }.freeze
 
     private
+
+    # Runs `block` with `observation` as the current OTel span and ends the
+    # span in `ensure` so block exceptions don't leak unfinished spans.
+    # Events are skipped because they auto-end at creation.
+    #
+    # Internal helper shared by {.observe} and {BaseObservation#start_observation};
+    # the latter reaches it via `Langfuse.__send__` since it lives behind `private`.
+    #
+    # @api private
+    def run_in_observation_context(observation, as_type, &block)
+      current_context = OpenTelemetry::Context.current
+      OpenTelemetry::Context.with_current(
+        OpenTelemetry::Trace.context_with_span(observation.otel_span, parent_context: current_context)
+      ) do
+        block.call(observation)
+      end
+    ensure
+      observation.end unless as_type.to_s == OBSERVATION_TYPES[:event]
+    end
 
     # @api private
     def resolve_trace_context(trace_id, parent_span_context)

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -50,6 +50,7 @@ require_relative "langfuse/otel_attributes"
 require_relative "langfuse/propagation"
 require_relative "langfuse/span_processor"
 require_relative "langfuse/observations"
+require_relative "langfuse/trace_id"
 require_relative "langfuse/score_client"
 require_relative "langfuse/text_prompt_client"
 require_relative "langfuse/chat_prompt_client"
@@ -296,6 +297,30 @@ module Langfuse
       client.flush_scores if @client
     end
 
+    # Generate a trace ID (deterministic when seeded, random otherwise).
+    #
+    # Use this to correlate Langfuse traces with external identifiers. The
+    # same seed always produces the same trace ID across the Ruby, Python,
+    # and JS SDKs (SHA-256 of the seed, first 16 bytes, as 32 hex chars).
+    #
+    # @param seed [String, nil] Optional deterministic seed
+    # @return [String] 32-character lowercase hex trace ID
+    #
+    # @example
+    #   trace_id = Langfuse.create_trace_id(seed: "order-12345")
+    #   Langfuse.observe("process", trace_id: trace_id) { |span| ... }
+    def create_trace_id(seed: nil)
+      TraceId.create(seed: seed)
+    end
+
+    # Generate an observation (span) ID (deterministic when seeded).
+    #
+    # @param seed [String, nil] Optional deterministic seed
+    # @return [String] 16-character lowercase hex observation ID
+    def create_observation_id(seed: nil)
+      TraceId.create_observation_id(seed: seed)
+    end
+
     # Reset global configuration and client (useful for testing)
     #
     # @return [void]
@@ -332,8 +357,14 @@ module Langfuse
     #   child = Langfuse.start_observation("llm-call", { model: "gpt-4" },
     #                                       as_type: :generation,
     #                                       parent_span_context: parent.otel_span.context)
-    def start_observation(name, attrs = {}, as_type: :span, parent_span_context: nil, start_time: nil,
-                          skip_validation: false)
+    #
+    # @example Attach to a deterministic trace ID
+    #   trace_id = Langfuse.create_trace_id(seed: "order-123")
+    #   root = Langfuse.start_observation("process-order", trace_id: trace_id)
+    # rubocop:disable Metrics/AbcSize, Metrics/ParameterLists
+    def start_observation(name, attrs = {}, as_type: :span, trace_id: nil, parent_span_context: nil,
+                          start_time: nil, skip_validation: false)
+      parent_span_context = resolve_trace_context(trace_id, parent_span_context)
       type_str = as_type.to_s
 
       unless skip_validation || valid_observation_type?(as_type)
@@ -364,6 +395,7 @@ module Langfuse
 
       observation
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/ParameterLists
 
     # User-facing convenience method for creating root observations
     #
@@ -385,28 +417,29 @@ module Langfuse
     #   obs = Langfuse.observe("operation", input: { data: "test" })
     #   obs.update(output: { result: "success" })
     #   obs.end
-    def observe(name, attrs = {}, as_type: :span, **kwargs, &block)
+    def observe(name, attrs = {}, as_type: :span, trace_id: nil, **kwargs, &block)
       # Merge positional attrs and keyword kwargs
       merged_attrs = attrs.to_h.merge(kwargs)
-      observation = start_observation(name, merged_attrs, as_type: as_type)
+      observation = start_observation(name, merged_attrs, as_type: as_type, trace_id: trace_id)
+      return observation unless block
 
-      if block
-        # Block-based API: auto-ends when block completes
-        # Set context and execute block
-        current_context = OpenTelemetry::Context.current
-        result = OpenTelemetry::Context.with_current(
-          OpenTelemetry::Trace.context_with_span(observation.otel_span, parent_context: current_context)
-        ) do
-          block.call(observation)
-        end
-        # Only end if not already ended (events auto-end in start_observation)
-        observation.end unless as_type.to_s == OBSERVATION_TYPES[:event]
-        result
-      else
-        # Stateful API - return observation
-        # Events already auto-ended in start_observation
-        observation
+      execute_observe_block(observation, as_type, &block)
+    end
+
+    # Runs an observe block with the observation set as the current OTel span,
+    # guaranteeing the span ends via ensure — even if the block raises.
+    # Events are excluded because they auto-end in {start_observation}.
+    #
+    # @api private
+    def execute_observe_block(observation, as_type, &block)
+      current_context = OpenTelemetry::Context.current
+      OpenTelemetry::Context.with_current(
+        OpenTelemetry::Trace.context_with_span(observation.otel_span, parent_context: current_context)
+      ) do
+        block.call(observation)
       end
+    ensure
+      observation.end unless as_type.to_s == OBSERVATION_TYPES[:event]
     end
 
     # Registry mapping observation type strings to their wrapper classes
@@ -424,6 +457,18 @@ module Langfuse
     }.freeze
 
     private
+
+    # Resolves a user-supplied `trace_id` / `parent_span_context` pair into a
+    # single parent context. Raises if both are supplied — they are mutually
+    # exclusive ways of specifying the parent trace.
+    #
+    # @api private
+    def resolve_trace_context(trace_id, parent_span_context)
+      return parent_span_context unless trace_id
+      raise ArgumentError, "Cannot specify both trace_id and parent_span_context" if parent_span_context
+
+      TraceId.to_span_context(trace_id)
+    end
 
     # Validates that an observation type is valid
     #

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -303,22 +303,16 @@ module Langfuse
     # same seed always produces the same trace ID across the Ruby, Python,
     # and JS SDKs (SHA-256 of the seed, first 16 bytes, as 32 hex chars).
     #
+    # @note Avoid PII or secrets as seeds. See {TraceId.create} for details.
     # @param seed [String, nil] Optional deterministic seed
     # @return [String] 32-character lowercase hex trace ID
+    # @raise [ArgumentError] if seed is not nil and not a String
     #
     # @example
     #   trace_id = Langfuse.create_trace_id(seed: "order-12345")
     #   Langfuse.observe("process", trace_id: trace_id) { |span| ... }
     def create_trace_id(seed: nil)
       TraceId.create(seed: seed)
-    end
-
-    # Generate an observation (span) ID (deterministic when seeded).
-    #
-    # @param seed [String, nil] Optional deterministic seed
-    # @return [String] 16-character lowercase hex observation ID
-    def create_observation_id(seed: nil)
-      TraceId.create_observation_id(seed: seed)
     end
 
     # Reset global configuration and client (useful for testing)
@@ -415,7 +409,7 @@ module Langfuse
       observation = start_observation(name, merged_attrs, as_type: as_type, trace_id: trace_id)
       return observation unless block
 
-      run_in_observation_context(observation, as_type, &block)
+      observation.send(:run_in_context, &block)
     end
 
     # Registry mapping observation type strings to their wrapper classes
@@ -434,31 +428,12 @@ module Langfuse
 
     private
 
-    # Runs `block` with `observation` as the current OTel span and ends the
-    # span in `ensure` so block exceptions don't leak unfinished spans.
-    # Events are skipped because they auto-end at creation.
-    #
-    # Internal helper shared by {.observe} and {BaseObservation#start_observation};
-    # the latter reaches it via `Langfuse.__send__` since it lives behind `private`.
-    #
-    # @api private
-    def run_in_observation_context(observation, as_type, &block)
-      current_context = OpenTelemetry::Context.current
-      OpenTelemetry::Context.with_current(
-        OpenTelemetry::Trace.context_with_span(observation.otel_span, parent_context: current_context)
-      ) do
-        block.call(observation)
-      end
-    ensure
-      observation.end unless as_type.to_s == OBSERVATION_TYPES[:event]
-    end
-
     # @api private
     def resolve_trace_context(trace_id, parent_span_context)
       return parent_span_context unless trace_id
       raise ArgumentError, "Cannot specify both trace_id and parent_span_context" if parent_span_context
 
-      TraceId.to_span_context(trace_id)
+      TraceId.send(:to_span_context, trace_id)
     end
 
     # @api private

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -361,16 +361,12 @@ module Langfuse
     # @example Attach to a deterministic trace ID
     #   trace_id = Langfuse.create_trace_id(seed: "order-123")
     #   root = Langfuse.start_observation("process-order", trace_id: trace_id)
-    # rubocop:disable Metrics/AbcSize, Metrics/ParameterLists
+    # rubocop:disable Metrics/ParameterLists
     def start_observation(name, attrs = {}, as_type: :span, trace_id: nil, parent_span_context: nil,
                           start_time: nil, skip_validation: false)
       parent_span_context = resolve_trace_context(trace_id, parent_span_context)
       type_str = as_type.to_s
-
-      unless skip_validation || valid_observation_type?(as_type)
-        valid_types = OBSERVATION_TYPES.values.sort.join(", ")
-        raise ArgumentError, "Invalid observation type: #{type_str}. Valid types: #{valid_types}"
-      end
+      validate_observation_type!(as_type, type_str) unless skip_validation
 
       otel_tracer = otel_tracer()
       otel_span = create_otel_span(
@@ -379,23 +375,14 @@ module Langfuse
         parent_span_context: parent_span_context,
         otel_tracer: otel_tracer
       )
+      apply_observation_attributes(otel_span, type_str, attrs)
 
-      # Serialize attributes
-      # Only set attributes if span is still recording (should always be true here, but guard for safety)
-      if otel_span.recording?
-        otel_attrs = OtelAttributes.create_observation_attributes(type_str, attrs.to_h, mask: configuration.mask)
-        otel_attrs.each { |key, value| otel_span.set_attribute(key, value) }
-      end
-
-      # Wrap in appropriate class (attributes already set on span above — pass nil to avoid double-masking)
       observation = wrap_otel_span(otel_span, type_str, otel_tracer)
-
       # Events auto-end immediately when created
       observation.end if type_str == OBSERVATION_TYPES[:event]
-
       observation
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/ParameterLists
+    # rubocop:enable Metrics/ParameterLists
 
     # User-facing convenience method for creating root observations
     #
@@ -418,20 +405,19 @@ module Langfuse
     #   obs.update(output: { result: "success" })
     #   obs.end
     def observe(name, attrs = {}, as_type: :span, trace_id: nil, **kwargs, &block)
-      # Merge positional attrs and keyword kwargs
       merged_attrs = attrs.to_h.merge(kwargs)
       observation = start_observation(name, merged_attrs, as_type: as_type, trace_id: trace_id)
       return observation unless block
 
-      execute_observe_block(observation, as_type, &block)
+      run_in_observation_context(observation, as_type, &block)
     end
 
-    # Runs an observe block with the observation set as the current OTel span,
-    # guaranteeing the span ends via ensure — even if the block raises.
-    # Events are excluded because they auto-end in {start_observation}.
+    # Runs `block` with `observation` as the current OTel span and ends the
+    # span in `ensure` so block exceptions don't leak unfinished spans.
+    # Events are skipped because they auto-end at creation.
     #
     # @api private
-    def execute_observe_block(observation, as_type, &block)
+    def run_in_observation_context(observation, as_type, &block)
       current_context = OpenTelemetry::Context.current
       OpenTelemetry::Context.with_current(
         OpenTelemetry::Trace.context_with_span(observation.otel_span, parent_context: current_context)
@@ -458,16 +444,29 @@ module Langfuse
 
     private
 
-    # Resolves a user-supplied `trace_id` / `parent_span_context` pair into a
-    # single parent context. Raises if both are supplied — they are mutually
-    # exclusive ways of specifying the parent trace.
-    #
     # @api private
     def resolve_trace_context(trace_id, parent_span_context)
       return parent_span_context unless trace_id
       raise ArgumentError, "Cannot specify both trace_id and parent_span_context" if parent_span_context
 
       TraceId.to_span_context(trace_id)
+    end
+
+    # @api private
+    def validate_observation_type!(as_type, type_str)
+      return if valid_observation_type?(as_type)
+
+      valid_types = OBSERVATION_TYPES.values.sort.join(", ")
+      raise ArgumentError, "Invalid observation type: #{type_str}. Valid types: #{valid_types}"
+    end
+
+    # @api private
+    def apply_observation_attributes(otel_span, type_str, attrs)
+      # Guard against ended spans — should always be recording here, but safe.
+      return unless otel_span.recording?
+
+      otel_attrs = OtelAttributes.create_observation_attributes(type_str, attrs.to_h, mask: configuration.mask)
+      otel_attrs.each { |key, value| otel_span.set_attribute(key, value) }
     end
 
     # Validates that an observation type is valid

--- a/lib/langfuse/observations.rb
+++ b/lib/langfuse/observations.rb
@@ -133,8 +133,7 @@ module Langfuse
     # @yield [observation] Optional block that receives the observation object
     # @return [BaseObservation, Object] The child observation (or block return value if block given)
     def start_observation(name, attrs = {}, as_type: :span, &block)
-      # Call module-level factory with parent context
-      # Skip validation to allow unknown types to fall back to Span
+      # Skip validation so unknown types fall back to Span in the factory.
       child = Langfuse.start_observation(
         name,
         attrs,
@@ -144,23 +143,7 @@ module Langfuse
       )
       return child unless block
 
-      execute_child_block(child, as_type, &block)
-    end
-
-    # Runs a child block with the child span set as the current OTel span and
-    # guarantees the child ends via ensure — even if the block raises.
-    # Events are excluded because they auto-end at creation.
-    #
-    # @api private
-    def execute_child_block(child, as_type, &block)
-      current_context = OpenTelemetry::Context.current
-      OpenTelemetry::Context.with_current(
-        OpenTelemetry::Trace.context_with_span(child.otel_span, parent_context: current_context)
-      ) do
-        block.call(child)
-      end
-    ensure
-      child.end unless as_type.to_s == OBSERVATION_TYPES[:event]
+      Langfuse.run_in_observation_context(child, as_type, &block)
     end
 
     # Sets observation-level input attributes.

--- a/lib/langfuse/observations.rb
+++ b/lib/langfuse/observations.rb
@@ -143,7 +143,9 @@ module Langfuse
       )
       return child unless block
 
-      Langfuse.run_in_observation_context(child, as_type, &block)
+      # `run_in_observation_context` is intentionally private on Langfuse to
+      # keep it out of the public API; reach it via __send__ from here.
+      Langfuse.__send__(:run_in_observation_context, child, as_type, &block)
     end
 
     # Sets observation-level input attributes.

--- a/lib/langfuse/observations.rb
+++ b/lib/langfuse/observations.rb
@@ -142,24 +142,25 @@ module Langfuse
         parent_span_context: @otel_span.context,
         skip_validation: true
       )
+      return child unless block
 
-      if block
-        # Block-based API: auto-ends when block completes
-        # Set context and execute block
-        current_context = OpenTelemetry::Context.current
-        result = OpenTelemetry::Context.with_current(
-          OpenTelemetry::Trace.context_with_span(child.otel_span, parent_context: current_context)
-        ) do
-          block.call(child)
-        end
-        # Only end if not already ended (events auto-end in start_observation)
-        child.end unless as_type.to_s == OBSERVATION_TYPES[:event]
-        result
-      else
-        # Stateful API - return observation
-        # Events already auto-ended in start_observation
-        child
+      execute_child_block(child, as_type, &block)
+    end
+
+    # Runs a child block with the child span set as the current OTel span and
+    # guarantees the child ends via ensure — even if the block raises.
+    # Events are excluded because they auto-end at creation.
+    #
+    # @api private
+    def execute_child_block(child, as_type, &block)
+      current_context = OpenTelemetry::Context.current
+      OpenTelemetry::Context.with_current(
+        OpenTelemetry::Trace.context_with_span(child.otel_span, parent_context: current_context)
+      ) do
+        block.call(child)
       end
+    ensure
+      child.end unless as_type.to_s == OBSERVATION_TYPES[:event]
     end
 
     # Sets observation-level input attributes.

--- a/lib/langfuse/observations.rb
+++ b/lib/langfuse/observations.rb
@@ -143,9 +143,7 @@ module Langfuse
       )
       return child unless block
 
-      # `run_in_observation_context` is intentionally private on Langfuse to
-      # keep it out of the public API; reach it via __send__ from here.
-      Langfuse.__send__(:run_in_observation_context, child, as_type, &block)
+      child.send(:run_in_context, &block)
     end
 
     # Sets observation-level input attributes.
@@ -246,6 +244,27 @@ module Langfuse
       else
         prompt
       end
+    end
+
+    private
+
+    # Runs the block with this observation as the active OTel span,
+    # then ends the span in ensure (events excluded — they auto-end).
+    # @api private
+    def run_in_context
+      parent_ctx = OpenTelemetry::Context.current
+      span_ctx = OpenTelemetry::Trace.context_with_span(@otel_span, parent_context: parent_ctx)
+      OpenTelemetry::Context.with_current(span_ctx) { yield self }
+    ensure
+      safe_end
+    end
+
+    # Ends the span, swallowing errors so ensure never masks a block exception.
+    # @api private
+    def safe_end
+      self.end unless @type == OBSERVATION_TYPES[:event]
+    rescue StandardError
+      nil
     end
   end
 

--- a/lib/langfuse/trace_id.rb
+++ b/lib/langfuse/trace_id.rb
@@ -20,9 +20,9 @@ module Langfuse
   #   trace_id = Langfuse::TraceId.create
   module TraceId
     TRACE_ID_PATTERN = /\A[0-9a-f]{32}\z/
-    OBSERVATION_ID_PATTERN = /\A[0-9a-f]{16}\z/
     INVALID_TRACE_ID = ("0" * 32)
-    INVALID_OBSERVATION_ID = ("0" * 16)
+
+    private_constant :TRACE_ID_PATTERN, :INVALID_TRACE_ID
 
     class << self
       # Generate a W3C trace ID (32 lowercase hex chars).
@@ -31,59 +31,46 @@ module Langfuse
       # With a seed, takes the first 16 bytes of SHA-256(seed) so the same
       # input always produces the same trace ID.
       #
-      # @param seed [String, nil] Optional seed for deterministic generation
+      # @note Avoid passing PII, secrets, or credentials as seeds — the raw seed
+      #   value appears in application code and may leak through logs/backtraces.
+      #   Use stable external identifiers (database PKs, UUIDs, request IDs).
+      # @param seed [String, nil] Optional seed for deterministic generation.
+      #   Must be a String if provided; non-String values raise ArgumentError
+      #   for cross-SDK parity (Python/JS both reject non-strings).
       # @return [String] 32-character lowercase hex trace ID
+      # @raise [ArgumentError] if seed is not nil and not a String
       def create(seed: nil)
         return OpenTelemetry::Trace.generate_trace_id.unpack1("H*") if seed.nil?
 
-        Digest::SHA256.digest(seed.to_s)[0, 16].unpack1("H*")
+        Digest::SHA256.digest(validate_seed!(seed))[0, 16].unpack1("H*")
       end
 
-      # Generate a W3C span ID (16 lowercase hex chars).
-      #
-      # With no seed, delegates to OpenTelemetry's random span ID generator.
-      # With a seed, takes the first 8 bytes of SHA-256(seed).
-      #
-      # @param seed [String, nil] Optional seed for deterministic generation
-      # @return [String] 16-character lowercase hex observation ID
-      def create_observation_id(seed: nil)
-        return OpenTelemetry::Trace.generate_span_id.unpack1("H*") if seed.nil?
+      private
 
-        Digest::SHA256.digest(seed.to_s)[0, 8].unpack1("H*")
+      # @api private
+      def validate_seed!(seed)
+        raise ArgumentError, "seed must be a String, got #{seed.class}" unless seed.is_a?(String)
+
+        # ASCII-8BIT strings (binary) often already hold valid UTF-8 bytes
+        # but can't be transcoded — re-tag them instead.
+        return seed.dup.force_encoding("UTF-8") if seed.encoding == Encoding::ASCII_8BIT
+
+        seed.encode("UTF-8")
       end
 
-      # @param trace_id [Object] Value to validate
-      # @return [Boolean] true when the value is a 32-char lowercase hex string
-      #   that is not the all-zero W3C "invalid" trace ID
+      # @api private
       def valid?(trace_id)
         return false unless trace_id.is_a?(String) && TRACE_ID_PATTERN.match?(trace_id)
 
-        # W3C trace-context: the all-zero trace ID is reserved as "invalid"
-        # and OpenTelemetry treats it as an invalid SpanContext.
         trace_id != INVALID_TRACE_ID
-      end
-
-      # @param id [Object] Value to validate
-      # @return [Boolean] true when the value is a 16-char lowercase hex string
-      #   that is not the all-zero W3C "invalid" span ID
-      def valid_observation_id?(id)
-        return false unless id.is_a?(String) && OBSERVATION_ID_PATTERN.match?(id)
-
-        # W3C trace-context: the all-zero span ID is reserved as "invalid".
-        id != INVALID_OBSERVATION_ID
       end
 
       # Build a sampled OpenTelemetry SpanContext carrying the given hex trace ID.
       #
-      # Passed as `parent_span_context:` to {Langfuse.start_observation}, this
-      # forces the next span onto the provided trace. A SpanContext also needs
-      # a span_id, so a random one is generated; it is never persisted — only
-      # the trace_id is consumed by the child span that gets created. This
-      # mirrors the Python SDK's `create_trace_id` / SpanContext wiring.
+      # A random span_id is generated as a placeholder — only the trace_id is
+      # consumed by the child span that gets created.
       #
-      # @param trace_id [String] 32-character lowercase hex trace ID
-      # @return [OpenTelemetry::Trace::SpanContext] sampled span context
-      # @raise [ArgumentError] if `trace_id` is not a valid trace ID
+      # @api private
       def to_span_context(trace_id)
         raise ArgumentError, "Invalid trace_id: #{trace_id.inspect}" unless valid?(trace_id)
 
@@ -91,6 +78,8 @@ module Langfuse
           trace_id: [trace_id].pack("H*"),
           span_id: OpenTelemetry::Trace.generate_span_id,
           trace_flags: OpenTelemetry::Trace::TraceFlags::SAMPLED,
+          # Cross-SDK parity: Python uses is_remote=False (_create_remote_parent_span).
+          # Changing this would alter ParentBased sampler behavior across SDKs.
           remote: false
         )
       end

--- a/lib/langfuse/trace_id.rb
+++ b/lib/langfuse/trace_id.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module Langfuse
+  # Deterministic and random trace/observation ID generation.
+  #
+  # Mirrors the Python and JS SDK helpers so the same seed produces the same
+  # trace ID across all three SDKs. This lets callers correlate Langfuse traces
+  # with external system identifiers (database primary keys, request IDs, etc.)
+  # and score or reference traces later without having to persist the generated
+  # Langfuse ID.
+  #
+  # @example Deterministic from an external ID
+  #   trace_id = Langfuse::TraceId.create(seed: "order-12345")
+  #   Langfuse.observe("process-order", trace_id: trace_id) { |span| ... }
+  #   Langfuse.create_score(name: "quality", value: 0.9, trace_id: trace_id)
+  #
+  # @example Random (no seed)
+  #   trace_id = Langfuse::TraceId.create
+  module TraceId
+    TRACE_ID_PATTERN = /\A[0-9a-f]{32}\z/
+    OBSERVATION_ID_PATTERN = /\A[0-9a-f]{16}\z/
+
+    class << self
+      # Generate a W3C trace ID (32 lowercase hex chars).
+      #
+      # With no seed, delegates to OpenTelemetry's random trace ID generator.
+      # With a seed, takes the first 16 bytes of SHA-256(seed) so the same
+      # input always produces the same trace ID.
+      #
+      # @param seed [String, nil] Optional seed for deterministic generation
+      # @return [String] 32-character lowercase hex trace ID
+      def create(seed: nil)
+        return OpenTelemetry::Trace.generate_trace_id.unpack1("H*") if seed.nil?
+
+        Digest::SHA256.digest(seed.to_s)[0, 16].unpack1("H*")
+      end
+
+      # Generate a W3C span ID (16 lowercase hex chars).
+      #
+      # With no seed, delegates to OpenTelemetry's random span ID generator.
+      # With a seed, takes the first 8 bytes of SHA-256(seed).
+      #
+      # @param seed [String, nil] Optional seed for deterministic generation
+      # @return [String] 16-character lowercase hex observation ID
+      def create_observation_id(seed: nil)
+        return OpenTelemetry::Trace.generate_span_id.unpack1("H*") if seed.nil?
+
+        Digest::SHA256.digest(seed.to_s)[0, 8].unpack1("H*")
+      end
+
+      # @param trace_id [Object] Value to validate
+      # @return [Boolean] true when the value is a 32-char lowercase hex string
+      def valid?(trace_id)
+        trace_id.is_a?(String) && TRACE_ID_PATTERN.match?(trace_id)
+      end
+
+      # @param id [Object] Value to validate
+      # @return [Boolean] true when the value is a 16-char lowercase hex string
+      def valid_observation_id?(id)
+        id.is_a?(String) && OBSERVATION_ID_PATTERN.match?(id)
+      end
+
+      # Build a sampled OpenTelemetry SpanContext from a hex trace ID.
+      #
+      # The returned SpanContext can be passed as `parent_span_context:` to
+      # {Langfuse.start_observation} to force a new root span onto the given
+      # trace ID. A random span ID is generated for the parent so OTel has a
+      # concrete parent span to attach to; downstream child spans attach to
+      # the real root span created by `start_observation`.
+      #
+      # @param trace_id [String] 32-character lowercase hex trace ID
+      # @return [OpenTelemetry::Trace::SpanContext] sampled span context
+      # @raise [ArgumentError] if `trace_id` is not a valid trace ID
+      def to_span_context(trace_id)
+        raise ArgumentError, "Invalid trace_id: #{trace_id.inspect}" unless valid?(trace_id)
+
+        OpenTelemetry::Trace::SpanContext.new(
+          trace_id: [trace_id].pack("H*"),
+          span_id: OpenTelemetry::Trace.generate_span_id,
+          trace_flags: OpenTelemetry::Trace::TraceFlags::SAMPLED,
+          remote: false
+        )
+      end
+    end
+  end
+end

--- a/lib/langfuse/trace_id.rb
+++ b/lib/langfuse/trace_id.rb
@@ -62,13 +62,13 @@ module Langfuse
         id.is_a?(String) && OBSERVATION_ID_PATTERN.match?(id)
       end
 
-      # Build a sampled OpenTelemetry SpanContext from a hex trace ID.
+      # Build a sampled OpenTelemetry SpanContext carrying the given hex trace ID.
       #
-      # The returned SpanContext can be passed as `parent_span_context:` to
-      # {Langfuse.start_observation} to force a new root span onto the given
-      # trace ID. A random span ID is generated for the parent so OTel has a
-      # concrete parent span to attach to; downstream child spans attach to
-      # the real root span created by `start_observation`.
+      # Passed as `parent_span_context:` to {Langfuse.start_observation}, this
+      # forces the next span onto the provided trace. A SpanContext also needs
+      # a span_id, so a random one is generated; it is never persisted — only
+      # the trace_id is consumed by the child span that gets created. This
+      # mirrors the Python SDK's `create_trace_id` / SpanContext wiring.
       #
       # @param trace_id [String] 32-character lowercase hex trace ID
       # @return [OpenTelemetry::Trace::SpanContext] sampled span context

--- a/lib/langfuse/trace_id.rb
+++ b/lib/langfuse/trace_id.rb
@@ -21,6 +21,8 @@ module Langfuse
   module TraceId
     TRACE_ID_PATTERN = /\A[0-9a-f]{32}\z/
     OBSERVATION_ID_PATTERN = /\A[0-9a-f]{16}\z/
+    INVALID_TRACE_ID = ("0" * 32)
+    INVALID_OBSERVATION_ID = ("0" * 16)
 
     class << self
       # Generate a W3C trace ID (32 lowercase hex chars).
@@ -52,14 +54,23 @@ module Langfuse
 
       # @param trace_id [Object] Value to validate
       # @return [Boolean] true when the value is a 32-char lowercase hex string
+      #   that is not the all-zero W3C "invalid" trace ID
       def valid?(trace_id)
-        trace_id.is_a?(String) && TRACE_ID_PATTERN.match?(trace_id)
+        return false unless trace_id.is_a?(String) && TRACE_ID_PATTERN.match?(trace_id)
+
+        # W3C trace-context: the all-zero trace ID is reserved as "invalid"
+        # and OpenTelemetry treats it as an invalid SpanContext.
+        trace_id != INVALID_TRACE_ID
       end
 
       # @param id [Object] Value to validate
       # @return [Boolean] true when the value is a 16-char lowercase hex string
+      #   that is not the all-zero W3C "invalid" span ID
       def valid_observation_id?(id)
-        id.is_a?(String) && OBSERVATION_ID_PATTERN.match?(id)
+        return false unless id.is_a?(String) && OBSERVATION_ID_PATTERN.match?(id)
+
+        # W3C trace-context: the all-zero span ID is reserved as "invalid".
+        id != INVALID_OBSERVATION_ID
       end
 
       # Build a sampled OpenTelemetry SpanContext carrying the given hex trace ID.

--- a/spec/langfuse/base_observation_spec.rb
+++ b/spec/langfuse/base_observation_spec.rb
@@ -192,6 +192,19 @@ RSpec.describe Langfuse::BaseObservation do
           expect(span_data.attributes["langfuse.observation.level"]).to eq("ERROR")
         end
       end
+
+      it "ends the child and re-raises when the block raises" do
+        child_ref = nil
+
+        expect do
+          observation.start_observation("boom") do |child|
+            child_ref = child
+            raise "kaboom"
+          end
+        end.to raise_error(RuntimeError, "kaboom")
+
+        expect(child_ref.otel_span.recording?).to be(false)
+      end
     end
 
     context "without block (stateful API)" do

--- a/spec/langfuse/trace_id_spec.rb
+++ b/spec/langfuse/trace_id_spec.rb
@@ -22,8 +22,15 @@ RSpec.describe Langfuse::TraceId do
       expect(described_class.create(seed: "a")).not_to eq(described_class.create(seed: "b"))
     end
 
-    it "coerces non-string seeds to strings" do
-      expect(described_class.create(seed: 42)).to eq(described_class.create(seed: "42"))
+    it "raises ArgumentError for non-String seeds" do
+      expect { described_class.create(seed: 42) }.to raise_error(ArgumentError, /must be a String/)
+      expect { described_class.create(seed: :foo) }.to raise_error(ArgumentError, /must be a String/)
+    end
+
+    it "normalizes ASCII-8BIT encoded strings to UTF-8" do
+      utf8 = "café"
+      binary = utf8.dup.force_encoding(Encoding::ASCII_8BIT)
+      expect(described_class.create(seed: binary)).to eq(described_class.create(seed: utf8))
     end
 
     it "returns different IDs across calls when unseeded" do
@@ -37,76 +44,36 @@ RSpec.describe Langfuse::TraceId do
     end
   end
 
-  describe ".create_observation_id" do
-    it "returns a 16-character lowercase hex string" do
-      id = described_class.create_observation_id
-      expect(id).to match(/\A[0-9a-f]{16}\z/)
-    end
-
-    it "is deterministic for the same seed" do
-      first = described_class.create_observation_id(seed: "span-x")
-      second = described_class.create_observation_id(seed: "span-x")
-      expect(first).to eq(second)
-    end
-
-    it "matches the SHA-256 reference algorithm for a known seed" do
-      expected = Digest::SHA256.digest("span-x")[0, 8].unpack1("H*")
-      expect(described_class.create_observation_id(seed: "span-x")).to eq(expected)
-    end
-  end
-
   describe ".valid?" do
     it "returns true for a 32-char lowercase hex string" do
-      expect(described_class.valid?("a" * 32)).to be(true)
-      expect(described_class.valid?("0123456789abcdef0123456789abcdef")).to be(true)
+      expect(described_class.send(:valid?, "a" * 32)).to be(true)
+      expect(described_class.send(:valid?, "0123456789abcdef0123456789abcdef")).to be(true)
     end
 
     it "returns false for wrong length" do
-      expect(described_class.valid?("a" * 31)).to be(false)
-      expect(described_class.valid?("a" * 33)).to be(false)
+      expect(described_class.send(:valid?, "a" * 31)).to be(false)
+      expect(described_class.send(:valid?, "a" * 33)).to be(false)
     end
 
     it "returns false for uppercase hex" do
-      expect(described_class.valid?("A" * 32)).to be(false)
+      expect(described_class.send(:valid?, "A" * 32)).to be(false)
     end
 
     it "returns false for non-hex characters" do
-      expect(described_class.valid?("g" * 32)).to be(false)
+      expect(described_class.send(:valid?, "g" * 32)).to be(false)
     end
 
     it "returns false for nil or non-strings" do
-      expect(described_class.valid?(nil)).to be(false)
-      expect(described_class.valid?(12_345)).to be(false)
+      expect(described_class.send(:valid?, nil)).to be(false)
+      expect(described_class.send(:valid?, 12_345)).to be(false)
     end
 
     it "returns false when the string contains a newline (anchor check)" do
-      # \A/\z anchors must reject multiline input that ^/$ would wrongly accept
-      expect(described_class.valid?("#{'a' * 32}\nextra")).to be(false)
+      expect(described_class.send(:valid?, "#{'a' * 32}\nextra")).to be(false)
     end
 
     it "returns false for the all-zero W3C invalid trace ID" do
-      # W3C trace-context: "0" * 32 is reserved as the invalid trace ID
-      # and OpenTelemetry treats it as an invalid SpanContext.
-      expect(described_class.valid?("0" * 32)).to be(false)
-    end
-  end
-
-  describe ".valid_observation_id?" do
-    it "returns true for a 16-char lowercase hex string" do
-      expect(described_class.valid_observation_id?("a" * 16)).to be(true)
-    end
-
-    it "returns false for wrong length" do
-      expect(described_class.valid_observation_id?("a" * 15)).to be(false)
-    end
-
-    it "returns false for nil" do
-      expect(described_class.valid_observation_id?(nil)).to be(false)
-    end
-
-    it "returns false for the all-zero W3C invalid span ID" do
-      # W3C trace-context: "0" * 16 is reserved as the invalid span ID.
-      expect(described_class.valid_observation_id?("0" * 16)).to be(false)
+      expect(described_class.send(:valid?, "0" * 32)).to be(false)
     end
   end
 
@@ -117,23 +84,28 @@ RSpec.describe Langfuse::TraceId do
 
     it "returns a SpanContext carrying the provided trace ID" do
       hex_trace_id = described_class.create(seed: "order-123")
-      ctx = described_class.to_span_context(hex_trace_id)
+      ctx = described_class.send(:to_span_context, hex_trace_id)
 
       expect(ctx).to be_a(OpenTelemetry::Trace::SpanContext)
       expect(ctx.trace_id.unpack1("H*")).to eq(hex_trace_id)
     end
 
     it "sets the SAMPLED trace flag" do
-      ctx = described_class.to_span_context(described_class.create(seed: "x"))
+      ctx = described_class.send(:to_span_context, described_class.create(seed: "x"))
       expect(ctx.trace_flags.sampled?).to be(true)
     end
 
+    it "marks the span context as non-remote (cross-SDK parity lock)" do
+      ctx = described_class.send(:to_span_context, described_class.create(seed: "parity"))
+      expect(ctx.remote?).to be(false)
+    end
+
     it "raises ArgumentError for an invalid trace ID" do
-      expect { described_class.to_span_context("not-valid") }.to raise_error(ArgumentError, /Invalid trace_id/)
+      expect { described_class.send(:to_span_context, "not-valid") }.to raise_error(ArgumentError, /Invalid trace_id/)
     end
 
     it "raises ArgumentError for nil" do
-      expect { described_class.to_span_context(nil) }.to raise_error(ArgumentError)
+      expect { described_class.send(:to_span_context, nil) }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/langfuse/trace_id_spec.rb
+++ b/spec/langfuse/trace_id_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "opentelemetry/sdk"
+
+RSpec.describe Langfuse::TraceId do
+  describe ".create" do
+    it "returns a 32-character lowercase hex string" do
+      trace_id = described_class.create
+      expect(trace_id).to be_a(String)
+      expect(trace_id.length).to eq(32)
+      expect(trace_id).to match(/\A[0-9a-f]{32}\z/)
+    end
+
+    it "is deterministic for the same seed" do
+      first = described_class.create(seed: "order-123")
+      second = described_class.create(seed: "order-123")
+      expect(first).to eq(second)
+    end
+
+    it "produces different IDs for different seeds" do
+      expect(described_class.create(seed: "a")).not_to eq(described_class.create(seed: "b"))
+    end
+
+    it "coerces non-string seeds to strings" do
+      expect(described_class.create(seed: 42)).to eq(described_class.create(seed: "42"))
+    end
+
+    it "returns different IDs across calls when unseeded" do
+      ids = Array.new(5) { described_class.create }
+      expect(ids.uniq.length).to eq(5)
+    end
+
+    it "matches the SHA-256 reference algorithm for a known seed" do
+      expected = Digest::SHA256.digest("order-12345")[0, 16].unpack1("H*")
+      expect(described_class.create(seed: "order-12345")).to eq(expected)
+    end
+  end
+
+  describe ".create_observation_id" do
+    it "returns a 16-character lowercase hex string" do
+      id = described_class.create_observation_id
+      expect(id).to match(/\A[0-9a-f]{16}\z/)
+    end
+
+    it "is deterministic for the same seed" do
+      first = described_class.create_observation_id(seed: "span-x")
+      second = described_class.create_observation_id(seed: "span-x")
+      expect(first).to eq(second)
+    end
+
+    it "matches the SHA-256 reference algorithm for a known seed" do
+      expected = Digest::SHA256.digest("span-x")[0, 8].unpack1("H*")
+      expect(described_class.create_observation_id(seed: "span-x")).to eq(expected)
+    end
+  end
+
+  describe ".valid?" do
+    it "returns true for a 32-char lowercase hex string" do
+      expect(described_class.valid?("a" * 32)).to be(true)
+      expect(described_class.valid?("0123456789abcdef0123456789abcdef")).to be(true)
+    end
+
+    it "returns false for wrong length" do
+      expect(described_class.valid?("a" * 31)).to be(false)
+      expect(described_class.valid?("a" * 33)).to be(false)
+    end
+
+    it "returns false for uppercase hex" do
+      expect(described_class.valid?("A" * 32)).to be(false)
+    end
+
+    it "returns false for non-hex characters" do
+      expect(described_class.valid?("g" * 32)).to be(false)
+    end
+
+    it "returns false for nil or non-strings" do
+      expect(described_class.valid?(nil)).to be(false)
+      expect(described_class.valid?(12_345)).to be(false)
+    end
+
+    it "returns false when the string contains a newline (anchor check)" do
+      # \A/\z anchors must reject multiline input that ^/$ would wrongly accept
+      expect(described_class.valid?("#{'a' * 32}\nextra")).to be(false)
+    end
+  end
+
+  describe ".valid_observation_id?" do
+    it "returns true for a 16-char lowercase hex string" do
+      expect(described_class.valid_observation_id?("a" * 16)).to be(true)
+    end
+
+    it "returns false for wrong length" do
+      expect(described_class.valid_observation_id?("a" * 15)).to be(false)
+    end
+
+    it "returns false for nil" do
+      expect(described_class.valid_observation_id?(nil)).to be(false)
+    end
+  end
+
+  describe ".to_span_context" do
+    before do
+      OpenTelemetry.tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider.new
+    end
+
+    it "returns a SpanContext carrying the provided trace ID" do
+      hex_trace_id = described_class.create(seed: "order-123")
+      ctx = described_class.to_span_context(hex_trace_id)
+
+      expect(ctx).to be_a(OpenTelemetry::Trace::SpanContext)
+      expect(ctx.trace_id.unpack1("H*")).to eq(hex_trace_id)
+    end
+
+    it "sets the SAMPLED trace flag" do
+      ctx = described_class.to_span_context(described_class.create(seed: "x"))
+      expect(ctx.trace_flags.sampled?).to be(true)
+    end
+
+    it "raises ArgumentError for an invalid trace ID" do
+      expect { described_class.to_span_context("not-valid") }.to raise_error(ArgumentError, /Invalid trace_id/)
+    end
+
+    it "raises ArgumentError for nil" do
+      expect { described_class.to_span_context(nil) }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/langfuse/trace_id_spec.rb
+++ b/spec/langfuse/trace_id_spec.rb
@@ -83,6 +83,12 @@ RSpec.describe Langfuse::TraceId do
       # \A/\z anchors must reject multiline input that ^/$ would wrongly accept
       expect(described_class.valid?("#{'a' * 32}\nextra")).to be(false)
     end
+
+    it "returns false for the all-zero W3C invalid trace ID" do
+      # W3C trace-context: "0" * 32 is reserved as the invalid trace ID
+      # and OpenTelemetry treats it as an invalid SpanContext.
+      expect(described_class.valid?("0" * 32)).to be(false)
+    end
   end
 
   describe ".valid_observation_id?" do
@@ -96,6 +102,11 @@ RSpec.describe Langfuse::TraceId do
 
     it "returns false for nil" do
       expect(described_class.valid_observation_id?(nil)).to be(false)
+    end
+
+    it "returns false for the all-zero W3C invalid span ID" do
+      # W3C trace-context: "0" * 16 is reserved as the invalid span ID.
+      expect(described_class.valid_observation_id?("0" * 16)).to be(false)
     end
   end
 

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -218,6 +218,25 @@ RSpec.describe Langfuse do
     end
   end
 
+  describe ".create_trace_id" do
+    it "delegates to TraceId.create with no seed" do
+      trace_id = described_class.create_trace_id
+      expect(trace_id).to match(/\A[0-9a-f]{32}\z/)
+    end
+
+    it "delegates to TraceId.create with a seed" do
+      expect(described_class.create_trace_id(seed: "abc")).to eq(Langfuse::TraceId.create(seed: "abc"))
+    end
+  end
+
+  describe ".create_observation_id" do
+    it "delegates to TraceId.create_observation_id" do
+      expect(described_class.create_observation_id(seed: "xyz")).to eq(
+        Langfuse::TraceId.create_observation_id(seed: "xyz")
+      )
+    end
+  end
+
   describe ".start_observation" do
     it "creates a root span observation" do
       observation = described_class.start_observation("test-span", { input: { data: "test" } })
@@ -352,6 +371,40 @@ RSpec.describe Langfuse do
         end.not_to raise_error
       end
     end
+
+    context "with a custom trace_id" do
+      it "attaches the root observation to the provided trace ID" do
+        trace_id = described_class.create_trace_id(seed: "root-seed")
+        observation = described_class.start_observation("root", {}, trace_id: trace_id)
+
+        expect(observation.trace_id).to eq(trace_id)
+      end
+
+      it "shares the trace ID with child observations created from the root" do
+        trace_id = described_class.create_trace_id(seed: "shared-seed")
+        root = described_class.start_observation("root", {}, trace_id: trace_id)
+        child = root.start_observation("child")
+
+        expect(child.trace_id).to eq(trace_id)
+      end
+
+      it "raises when both trace_id and parent_span_context are provided" do
+        parent = described_class.start_observation("parent", {})
+        expect do
+          described_class.start_observation(
+            "child", {},
+            trace_id: described_class.create_trace_id(seed: "x"),
+            parent_span_context: parent.otel_span.context
+          )
+        end.to raise_error(ArgumentError, /Cannot specify both trace_id and parent_span_context/)
+      end
+
+      it "raises ArgumentError for an invalid trace_id" do
+        expect do
+          described_class.start_observation("bad", {}, trace_id: "not-a-trace-id")
+        end.to raise_error(ArgumentError, /Invalid trace_id/)
+      end
+    end
   end
 
   describe ".observe" do
@@ -414,6 +467,49 @@ RSpec.describe Langfuse do
         expect do
           described_class.observe("test", {}, as_type: nil)
         end.to raise_error(ArgumentError, /Invalid observation type/)
+      end
+    end
+
+    context "with a custom trace_id" do
+      it "creates an observation attached to the custom trace ID" do
+        trace_id = described_class.create_trace_id(seed: "observe-seed")
+        captured = nil
+        described_class.observe("root", trace_id: trace_id) { |obs| captured = obs.trace_id }
+
+        expect(captured).to eq(trace_id)
+      end
+
+      it "propagates the trace ID to children started inside the block" do
+        trace_id = described_class.create_trace_id(seed: "propagate-seed")
+        child_trace_id = nil
+
+        described_class.observe("root", trace_id: trace_id) do |root|
+          root.start_observation("child") { |child| child_trace_id = child.trace_id }
+        end
+
+        expect(child_trace_id).to eq(trace_id)
+      end
+
+      it "raises ArgumentError for an invalid trace_id" do
+        expect do
+          described_class.observe("root", trace_id: "invalid") { |_| }
+        end.to raise_error(ArgumentError, /Invalid trace_id/)
+      end
+    end
+
+    context "when the block raises" do
+      it "ends the observation and re-raises the exception" do
+        observation_ref = nil
+
+        expect do
+          described_class.observe("boom") do |obs|
+            observation_ref = obs
+            raise "kaboom"
+          end
+        end.to raise_error(RuntimeError, "kaboom")
+
+        # Ensure block ran — span is no longer recording
+        expect(observation_ref.otel_span.recording?).to be(false)
       end
     end
   end

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -229,14 +229,6 @@ RSpec.describe Langfuse do
     end
   end
 
-  describe ".create_observation_id" do
-    it "delegates to TraceId.create_observation_id" do
-      expect(described_class.create_observation_id(seed: "xyz")).to eq(
-        Langfuse::TraceId.create_observation_id(seed: "xyz")
-      )
-    end
-  end
-
   describe ".start_observation" do
     it "creates a root span observation" do
       observation = described_class.start_observation("test-span", { input: { data: "test" } })
@@ -404,6 +396,12 @@ RSpec.describe Langfuse do
           described_class.start_observation("bad", {}, trace_id: "not-a-trace-id")
         end.to raise_error(ArgumentError, /Invalid trace_id/)
       end
+
+      it "rejects the all-zero W3C invalid trace ID" do
+        expect do
+          described_class.start_observation("bad", {}, trace_id: "0" * 32)
+        end.to raise_error(ArgumentError, /Invalid trace_id/)
+      end
     end
   end
 
@@ -495,6 +493,12 @@ RSpec.describe Langfuse do
           described_class.observe("root", trace_id: "invalid") { |_| }
         end.to raise_error(ArgumentError, /Invalid trace_id/)
       end
+
+      it "rejects the all-zero W3C invalid trace ID" do
+        expect do
+          described_class.observe("root", trace_id: "0" * 32) { |_| }
+        end.to raise_error(ArgumentError, /Invalid trace_id/)
+      end
     end
 
     context "when the block raises" do
@@ -510,6 +514,34 @@ RSpec.describe Langfuse do
 
         # Ensure block ran — span is no longer recording
         expect(observation_ref.otel_span.recording?).to be(false)
+      end
+
+      it "ends the observation even with a custom trace_id" do
+        trace_id = described_class.create_trace_id(seed: "ensure-test")
+        observation_ref = nil
+
+        expect do
+          described_class.observe("boom", trace_id: trace_id) do |obs|
+            observation_ref = obs
+            raise "kaboom"
+          end
+        end.to raise_error(RuntimeError, "kaboom")
+
+        expect(observation_ref.trace_id).to eq(trace_id)
+        expect(observation_ref.otel_span.recording?).to be(false)
+      end
+
+      it "does not mask the block exception when observation.end raises" do
+        observation_ref = nil
+
+        expect do
+          described_class.observe("outer") do |obs|
+            observation_ref = obs
+            # Stub finish to raise after the block captures the ref
+            allow(obs.otel_span).to receive(:finish).and_raise(RuntimeError, "end-boom")
+            raise ArgumentError, "original"
+          end
+        end.to raise_error(ArgumentError, "original")
       end
     end
   end


### PR DESCRIPTION
#### `TL;DR`
Add `Langfuse::TraceId` for deterministic/custom trace IDs and wire `trace_id:` into `start_observation` / `observe`, matching the Python and JS SDKs.

#### `Why`
Users need to correlate external system IDs (DB primary keys, request IDs) with Langfuse traces — e.g. to score a trace later from a background job or link traces across services. An external PR (#69) attempted this but had bugs (regex anchors, implicit nil var, rubocop disables) and lacked the deterministic `create_trace_id(seed:)` helper both reference SDKs expose. This change implements the reference SDK surface cleanly and fixes a pre-existing ensure-block bug on `observe` / `BaseObservation#start_observation` discovered along the way.

**What's in the change**
- New `Langfuse::TraceId` module — `.create(seed:)`, `.create_observation_id(seed:)`, `.valid?`, `.valid_observation_id?`, `.to_span_context`. Uses `\A`/`\z` anchors and `SHA-256` matching the Python/JS SDKs so the same seed produces the same trace ID across all three.
- `Langfuse.create_trace_id(seed:)` / `Langfuse.create_observation_id(seed:)` flat-API convenience methods.
- `trace_id:` keyword on `Langfuse.start_observation` and `Langfuse.observe`; mutually exclusive with `parent_span_context:`. Invalid IDs raise `ArgumentError`.
- Fixed ensure-block bug in `Langfuse.observe` and `BaseObservation#start_observation` — exceptions in the block now reliably end the span via `ensure` and re-raise.
- Verified end-to-end against live Langfuse: created a deterministic trace, added a child observation and a score using the same trace_id, fetched the trace via the API and confirmed `id`, observations (2), score (1) and tags all present.

#### `Checklist`
- [x] Has label
- [x] Has linked issue
- [x] Tests added for new behavior
- [ ] Docs updated (if user-facing)

Closes ML-964
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simplepractice/langfuse-rb/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
