### PR TITLE
fix(deps): bump faraday, json, addressable to patch CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (3.3.1)
@@ -27,7 +27,7 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dotenv (2.8.1)
-    faraday (2.14.0)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -41,7 +41,7 @@ GEM
     googleapis-common-protos-types (1.22.0)
       google-protobuf (~> 4.26)
     hashdiff (1.2.1)
-    json (2.15.1)
+    json (2.19.3)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)


### PR DESCRIPTION
#### `TL;DR`
Patch three Wiz-surfaced CVEs on `main` by bumping `faraday`, `json`, and `addressable` in `Gemfile.lock`.

#### `Why`
Wiz code scanning flagged four open alerts against `Gemfile.lock` on `main`. Three are upgradable CVE fixes; one (`diff-lcs` restrictive license) is a dev-only transitive and will be dismissed separately.

| # | Severity | Gem | Fix | CVE |
|---|---|---|---|---|
| #10 | High | addressable | 2.8.7 → 2.9.0 | CVE-2026-35611 (ReDoS in URI templates) |
| #8 | High | json | 2.15.1 → 2.19.3 | CVE-2026-33210 (format string injection) |
| #7 | Medium | faraday | 2.14.0 → 2.14.1 | CVE-2026-25765 (SSRF via protocol-relative URL) |

**Blast radius:**
- `faraday` is a direct runtime dep — SSRF fix reaches users of the gem.
- `json` is a runtime transitive via `faraday`.
- `addressable` is dev-only (via `webmock`).

Scoped update (`bundle update --conservative`) so the diff is just these three gems.

#### `Checklist`
- [x] Has label
- [x] Has linked issue
- [x] Tests added for new behavior (N/A — dep bump; full suite passes, coverage 98.05%)
- [x] Docs updated (if user-facing) (N/A)

Closes ML-971
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simplepractice/langfuse-rb/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
