### PR TITLE
[ML-973] docs: align docs with implementation

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -780,8 +780,9 @@ Create a score for a trace or observation.
 **Signature:**
 
 ```ruby
-create_score(name:, value:, trace_id: nil, observation_id: nil, comment: nil, metadata: nil,
-             data_type: :numeric, dataset_run_id: nil, config_id: nil)
+create_score(name:, value:, id: nil, trace_id: nil, session_id: nil, observation_id: nil,
+             comment: nil, metadata: nil, environment: nil, data_type: :numeric,
+             dataset_run_id: nil, config_id: nil)
 ```
 
 **Parameters:**
@@ -790,15 +791,16 @@ create_score(name:, value:, trace_id: nil, observation_id: nil, comment: nil, me
 | ---------------- | ---------------------- | -------- | ----------------------------------------- |
 | `name`           | String                 | Yes      | Score name                                |
 | `value`          | Numeric/String/Boolean | Yes      | Score value                               |
+| `id`             | String                 | No       | Custom score ID                           |
 | `trace_id`       | String                 | No       | Trace ID to score                         |
+| `session_id`     | String                 | No       | Session ID to associate with the score    |
 | `observation_id` | String                 | No       | Observation ID to score                   |
 | `comment`        | String                 | No       | Score comment                             |
 | `metadata`       | Hash                   | No       | Additional metadata                       |
+| `environment`    | String                 | No       | Environment tag for the score             |
 | `data_type`      | Symbol                 | No       | `:numeric`, `:boolean`, or `:categorical` |
 | `dataset_run_id` | String                 | No       | Dataset run ID to associate with          |
 | `config_id`      | String                 | No       | Score config ID                           |
-
-**Note:** Must provide at least one of `trace_id` or `observation_id`.
 
 **Example:**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -233,13 +233,13 @@ config.logger = Logger.new(IO::NULL)
 - **Type:** Boolean
 - **Default:** `true`
 - **Status:** Implemented for OpenTelemetry batching; ActiveJob integration is not implemented
-- **Description:** Controls OpenTelemetry export behavior. When `true`, spans are exported in the background on a schedule. When `false`, spans are queued and exported on explicit flush with a long schedule delay.
+- **Description:** Controls OpenTelemetry export behavior. When `true`, spans are exported in the background on a schedule. When `false`, spans are still batched with a longer schedule delay and are typically flushed explicitly at lifecycle boundaries.
 
 ```ruby
 config.tracing_async = true
 ```
 
-**Current Behavior:** Uses OpenTelemetry `BatchSpanProcessor` in both modes. Async mode uses `flush_interval` for scheduled export; sync mode uses a long schedule delay and relies on explicit `force_flush`.
+**Current Behavior:** Uses OpenTelemetry `BatchSpanProcessor` in both modes. Async mode uses `flush_interval` for scheduled export; sync mode uses a 60-second schedule delay and is usually paired with explicit `force_flush` for deterministic delivery timing.
 
 #### `job_queue` ⚠️ Experimental
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -205,7 +205,7 @@ end
 ```ruby
 warmer = Langfuse::CacheWarmer.new
 warmer.warm!(["prompt1", "prompt2", "nonexistent"])
-# => Langfuse::CacheWarmingError: Failed to warm cache for 1 prompt(s)
+# => Langfuse::CacheWarmingError: Failed to cache prompts: nonexistent
 ```
 
 **Solutions:**


### PR DESCRIPTION
#### `TL;DR`
Align docs with current implementation for scoring, tracing export behavior, and cache warming errors.

#### `Why`
Automated docs audit found concrete docs/code drift that can mislead integration behavior and debugging expectations.

#### `Checklist`
- [x] Has label
- [x] Has linked issue
- [ ] Tests added for new behavior
- [x] Docs updated (if user-facing)

Closes ML-973

## Summary
- Updated `docs/API_REFERENCE.md` scoring signature and parameter table to include implemented `id`, `session_id`, and `environment` options.
- Removed incorrect hard requirement that one of `trace_id` or `observation_id` must be present for `create_score`.
- Updated `docs/CONFIGURATION.md` to reflect actual `tracing_async` behavior in sync mode (`BatchSpanProcessor` with 60s delay; explicit flush recommended for determinism).
- Updated `docs/ERROR_HANDLING.md` `CacheWarmingError` example message to match raised error text in `CacheWarmer#warm!`.

## Fixes Addressed
- Scoring API contract mismatch in docs.
- Tracing sync export semantics wording drift.
- Cache warming exception example mismatch.

## Validation Checklist
- [x] `npx --yes langfuse-cli api __schema`
- [x] `npx --yes langfuse-cli api prompts get --help`
- [ ] `bundle exec rspec` (blocked: local Bundler executable mismatch)
- [ ] `bundle exec rubocop` (blocked: local Bundler executable mismatch)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simplepractice/langfuse-rb/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
