### PR TITLE
[AAI-34] Fix #71: make tracing isolated-by-default with lazy setup and smart export filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.ruby == '3.4'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage/coverage.json
           flags: unittests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Langfuse.tracer_provider`, `should_export_span`, and public span-filter helpers for explicit OpenTelemetry integration
+
+### Changed
+- Breaking: tracing is isolated by default and `Langfuse.configure` no longer installs Langfuse into `OpenTelemetry.tracer_provider`
+
 ## [0.7.0] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- `Langfuse.tracer_provider`, `should_export_span`, and public span-filter helpers for explicit OpenTelemetry integration
-
-### Changed
-- Breaking: tracing is isolated by default and `Langfuse.configure` no longer installs Langfuse into `OpenTelemetry.tracer_provider`
-
 ## [0.7.0] - 2026-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Langfuse.configure do |config|
 end
 ```
 
-> Langfuse tracing is isolated by default. `Langfuse.configure` stores configuration only; it does not replace `OpenTelemetry.tracer_provider` or `OpenTelemetry.propagation`.
+> Langfuse tracing is isolated by default. `Langfuse.configure` stores configuration only; it does not replace `OpenTelemetry.tracer_provider`.
 
 > Fetch and use a prompt
 
@@ -85,18 +85,15 @@ end
 > Explicit OpenTelemetry global install (optional)
 
 ```ruby
-require "opentelemetry/trace/propagation/trace_context"
-
 Langfuse.configure do |config|
   config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
   config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
 end
 
 OpenTelemetry.tracer_provider = Langfuse.tracer_provider
-OpenTelemetry.propagation = OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator.new
 ```
 
-If you install Langfuse globally, you own that lifecycle. `Langfuse.shutdown` and `Langfuse.reset!` stop the internal provider, so reconfigure and reinstall the provider and any propagators you want after resets.
+If you install Langfuse globally, you own that lifecycle. `Langfuse.shutdown` and `Langfuse.reset!` stop the internal provider, so reconfigure and reinstall it after resets.
 
 > Filter exported spans (optional)
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Langfuse.configure do |config|
   config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
   config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
   config.should_export_span = lambda { |span|
-    Langfuse.is_default_export_span(span) &&
+    Langfuse.default_export_span?(span) &&
       span.instrumentation_scope&.name != "my_framework.worker"
   }
 end

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Langfuse.configure do |config|
 end
 ```
 
-> Langfuse tracing is isolated by default. `Langfuse.configure` stores configuration only; it does not replace `OpenTelemetry.tracer_provider`.
+> Langfuse tracing is isolated by default. `Langfuse.configure` stores configuration only; it does not replace `OpenTelemetry.tracer_provider` or `OpenTelemetry.propagation`.
 
 > Fetch and use a prompt
 
@@ -85,15 +85,18 @@ end
 > Explicit OpenTelemetry global install (optional)
 
 ```ruby
+require "opentelemetry/trace/propagation/trace_context"
+
 Langfuse.configure do |config|
   config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
   config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
 end
 
 OpenTelemetry.tracer_provider = Langfuse.tracer_provider
+OpenTelemetry.propagation = OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator.new
 ```
 
-If you install Langfuse globally, you own that lifecycle. `Langfuse.shutdown` and `Langfuse.reset!` stop the internal provider, so reconfigure and reinstall it after resets.
+If you install Langfuse globally, you own that lifecycle. `Langfuse.shutdown` and `Langfuse.reset!` stop the internal provider, so reconfigure and reinstall the provider and any propagators you want after resets.
 
 > Filter exported spans (optional)
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Langfuse.configure do |config|
 end
 ```
 
+> Langfuse tracing is isolated by default. `Langfuse.configure` stores configuration only; it does not replace `OpenTelemetry.tracer_provider`.
+
 > Fetch and use a prompt
 
 ```ruby
@@ -79,6 +81,34 @@ Langfuse.observe("chat-completion", as_type: :generation) do |gen|
   )
 end
 ```
+
+> Explicit OpenTelemetry global install (optional)
+
+```ruby
+Langfuse.configure do |config|
+  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
+end
+
+OpenTelemetry.tracer_provider = Langfuse.tracer_provider
+```
+
+If you install Langfuse globally, you own that lifecycle. `Langfuse.shutdown` and `Langfuse.reset!` stop the internal provider, so reconfigure and reinstall it after resets.
+
+> Filter exported spans (optional)
+
+```ruby
+Langfuse.configure do |config|
+  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
+  config.should_export_span = lambda { |span|
+    Langfuse.is_default_export_span(span) &&
+      span.instrumentation_scope&.name != "my_framework.worker"
+  }
+end
+```
+
+`should_export_span` runs synchronously on every ended span in the application thread. Keep it allocation-light, non-blocking, and free of network/database calls.
 
 > [!IMPORTANT]
 > For complete reference see [docs](./docs/) section.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -54,6 +54,7 @@ Block receives a configuration object with these properties:
 | `job_queue`                    | Symbol  | No       | `:default`                     | ⚠️ Experimental (not implemented) |
 | `environment`                  | String  | No       | `nil`                          | Default trace environment          |
 | `release`                      | String  | No       | `nil`                          | Default release identifier         |
+| `should_export_span`           | `#call` | No       | `nil`                          | Span export filter callback        |
 | `mask`                         | `#call` | No       | `nil`                          | Mask callable for input/output/metadata (receives `data:` keyword) |
 
 **Example:**
@@ -106,6 +107,29 @@ Langfuse.reset!
 RSpec.configure do |config|
   config.before { Langfuse.reset! }
 end
+```
+
+### `Langfuse.tracer_provider`
+
+Return Langfuse's internal tracer provider so you can explicitly install it as the global OpenTelemetry provider.
+
+**Signature:**
+
+```ruby
+Langfuse.tracer_provider # => OpenTelemetry::SDK::Trace::TracerProvider
+```
+
+**Raises:** `ConfigurationError` if `public_key`, `secret_key`, or `base_url` are not configured
+
+**Example:**
+
+```ruby
+Langfuse.configure do |config|
+  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
+end
+
+OpenTelemetry.tracer_provider = Langfuse.tracer_provider
 ```
 
 ## Client Access

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -286,13 +286,13 @@ end
 
 **Why?**
 - Industry standard (CNCF)
-- Automatic distributed tracing (W3C Trace Context)
+- W3C Trace Context compatibility when the host app configures propagation
 - Works with existing APM tools (Datadog, New Relic, etc.)
-- Battle-tested context propagation
+- Battle-tested context and propagation model
 
 **Trade-offs:**
 - ✅ More robust, future-proof
-- ✅ Automatic distributed tracing
+- ✅ Cross-service tracing when the app installs an OpenTelemetry propagator
 - ❌ ~10 additional gem dependencies
 - ❌ Slightly more complex setup
 
@@ -511,7 +511,7 @@ User Code
 
 **Why OpenTelemetry?**
 - CNCF standard for distributed tracing
-- Automatic context propagation (W3C Trace Context)
+- Supports W3C Trace Context when the host app configures a propagator
 - Works with existing APM tools
 - Future-proof (industry direction)
 - OTLP export protocol (standardized)
@@ -520,7 +520,7 @@ User Code
 - **OTLP Exporter** - Sends spans to Langfuse via `/api/public/otel/v1/traces`
 - **BatchSpanProcessor** - Batches spans for efficient export
 - **SpanProcessor** - Custom processor for attribute propagation
-- **W3C TraceContext Propagator** - Distributed tracing across services
+- **Application-configured W3C TraceContext Propagator** - Optional cross-service propagation outside the SDK
 
 ## Performance Considerations
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -284,7 +284,7 @@ config.release = "2024.1"
 
 ```ruby
 config.should_export_span = lambda { |span|
-  Langfuse.is_default_export_span(span) &&
+  Langfuse.default_export_span?(span) &&
     span.instrumentation_scope&.name != "my_framework.worker"
 }
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,6 +16,8 @@ end
 
 Call this once at application startup (Rails initializer, boot script, etc.).
 
+`Langfuse.configure` only stores configuration. Module-level tracing initializes lazily on first use, and Langfuse does not install itself into the global OpenTelemetry tracer provider unless you opt in with `Langfuse.tracer_provider`.
+
 ## All Configuration Options
 
 ### Required
@@ -274,6 +276,27 @@ config.environment = "production"
 config.release = "2024.1"
 ```
 
+#### `should_export_span`
+
+- **Type:** `#call` (Proc, Lambda, Method, or any object responding to `call`) or `nil`
+- **Default:** `nil` (uses Langfuse's default export filter)
+- **Description:** Controls whether an ended span is exported to Langfuse
+
+```ruby
+config.should_export_span = lambda { |span|
+  Langfuse.is_default_export_span(span) &&
+    span.instrumentation_scope&.name != "my_framework.worker"
+}
+```
+
+Default behavior exports:
+
+- Langfuse SDK spans
+- Spans with `gen_ai.*` attributes
+- Spans from conservative LLM-related instrumentation scopes such as `langsmith.*`, `openinference.*`, and `opentelemetry.instrumentation.anthropic.*`
+
+The allowlist is intentionally conservative. It exists to include obvious LLM-related scopes, not every Ruby instrumentation namespace.
+
 #### `mask`
 
 - **Type:** `#call` (Proc, Lambda, or any object responding to `call`) or `nil`
@@ -292,6 +315,46 @@ config.mask = lambda { |data:|
 ```
 
 See [TRACING.md](TRACING.md#masking) for usage patterns and behavior details.
+
+## Tracing Behavior and OpenTelemetry Ownership
+
+Tracing is isolated by default:
+
+- `Langfuse.configure` does not mutate `OpenTelemetry.tracer_provider`
+- `Langfuse.observe(...)` uses Langfuse's internal tracer provider once tracing is ready
+- If `public_key`, `secret_key`, or `base_url` are missing, module-level tracing falls back to a no-op tracer and logs one warning
+
+If you want Langfuse to own the global OpenTelemetry provider, install it explicitly:
+
+```ruby
+Langfuse.configure do |config|
+  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
+end
+
+OpenTelemetry.tracer_provider = Langfuse.tracer_provider
+```
+
+That global install is a lifecycle commitment. `Langfuse.shutdown` and `Langfuse.reset!` stop the internal provider. If you reset or reconfigure Langfuse, reinstall `OpenTelemetry.tracer_provider = Langfuse.tracer_provider` afterward.
+
+After the first successful tracing initialization, these settings require `Langfuse.reset!` before changes take effect:
+
+- `public_key`
+- `secret_key`
+- `base_url`
+- `environment`
+- `release`
+- `should_export_span`
+- `tracing_async`
+- `batch_size`
+- `flush_interval`
+
+That includes processor tuning. Changing `batch_size` or `flush_interval` after tracing is already live will not rebuild the exporter pipeline until reset.
+
+Performance note for `should_export_span`:
+
+- It runs synchronously on every ended span in the application thread
+- Keep it allocation-light, non-blocking, and free of network/database calls
 
 ## Environment Variables
 
@@ -460,6 +523,7 @@ Validation rules:
 - `secret_key` must be present
 - `cache_backend` must be `:memory` or `:rails`
 - If `:rails`, Rails must be defined
+- `should_export_span` must respond to `#call` (if set)
 - `mask` must respond to `#call` (if set)
 
 ## Accessing Current Configuration

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -321,21 +321,25 @@ See [TRACING.md](TRACING.md#masking) for usage patterns and behavior details.
 Tracing is isolated by default:
 
 - `Langfuse.configure` does not mutate `OpenTelemetry.tracer_provider`
+- `Langfuse.configure` does not mutate `OpenTelemetry.propagation`
 - `Langfuse.observe(...)` uses Langfuse's internal tracer provider once tracing is ready
 - If `public_key`, `secret_key`, or `base_url` are missing, module-level tracing falls back to a no-op tracer and logs one warning
 
 If you want Langfuse to own the global OpenTelemetry provider, install it explicitly:
 
 ```ruby
+require "opentelemetry/trace/propagation/trace_context"
+
 Langfuse.configure do |config|
   config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
   config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
 end
 
 OpenTelemetry.tracer_provider = Langfuse.tracer_provider
+OpenTelemetry.propagation = OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator.new
 ```
 
-That global install is a lifecycle commitment. `Langfuse.shutdown` and `Langfuse.reset!` stop the internal provider. If you reset or reconfigure Langfuse, reinstall `OpenTelemetry.tracer_provider = Langfuse.tracer_provider` afterward.
+That global install is a lifecycle commitment. `Langfuse.shutdown` and `Langfuse.reset!` stop the internal provider. If you reset or reconfigure Langfuse, reinstall the tracer provider and any propagators you want afterward.
 
 After the first successful tracing initialization, these settings require `Langfuse.reset!` before changes take effect:
 

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -849,7 +849,18 @@ Your traces will appear in:
 
 ### W3C Trace Context
 
-The SDK uses the [W3C Trace Context](https://www.w3.org/TR/trace-context/) standard for distributed tracing:
+Langfuse spans are compatible with the [W3C Trace Context](https://www.w3.org/TR/trace-context/) standard for distributed tracing, but the SDK does not install a global propagator for you. If you want cross-service propagation, configure `OpenTelemetry.propagation` in your application:
+
+```ruby
+require "opentelemetry/trace/propagation/trace_context"
+
+OpenTelemetry.propagation =
+  OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator.new
+```
+
+That global OpenTelemetry propagator is separate from `Langfuse::Propagation`, which handles Langfuse-specific trace attributes and optional baggage propagation.
+
+With an application-configured propagator, traces can flow across services using headers like:
 
 ```
 traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -44,6 +44,7 @@ require_relative "langfuse/prompt_cache"
 require_relative "langfuse/rails_cache_adapter"
 require_relative "langfuse/cache_warmer"
 require_relative "langfuse/api_client"
+require_relative "langfuse/span_filter"
 require_relative "langfuse/otel_setup"
 require_relative "langfuse/masking"
 require_relative "langfuse/otel_attributes"
@@ -91,10 +92,6 @@ module Langfuse
     #   end
     def configure
       yield(configuration)
-
-      # Auto-initialize OpenTelemetry
-      OtelSetup.setup(configuration)
-
       configuration
     end
 
@@ -103,6 +100,28 @@ module Langfuse
     # @return [Client] the global client instance
     def client
       @client ||= Client.new(configuration)
+    end
+
+    # Return Langfuse's internal tracer provider for explicit global OpenTelemetry installation.
+    #
+    # @return [OpenTelemetry::SDK::Trace::TracerProvider]
+    # @raise [ConfigurationError] if tracing is not fully configured
+    #
+    # @example
+    #   Langfuse.configure do |config|
+    #     config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+    #     config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
+    #   end
+    #
+    #   OpenTelemetry.tracer_provider = Langfuse.tracer_provider
+    def tracer_provider
+      unless tracing_config_ready?
+        raise ConfigurationError,
+              "Langfuse tracing is disabled until public_key, secret_key, and base_url are configured."
+      end
+
+      OtelSetup.setup(configuration) unless OtelSetup.initialized?
+      OtelSetup.tracer_provider
     end
 
     # Shutdown Langfuse and flush any pending traces and scores
@@ -323,10 +342,14 @@ module Langfuse
       OtelSetup.shutdown(timeout: 5) if OtelSetup.initialized?
       @configuration = nil
       @client = nil
+      @noop_tracer = nil
+      @tracing_disabled_warning_emitted = false
     rescue StandardError
       # Ignore shutdown errors during reset (e.g., in tests)
       @configuration = nil
       @client = nil
+      @noop_tracer = nil
+      @tracing_disabled_warning_emitted = false
     end
 
     # Creates a new observation (root or child)
@@ -478,7 +501,10 @@ module Langfuse
     #
     # @return [OpenTelemetry::SDK::Trace::Tracer] The OTel tracer
     def otel_tracer
-      OpenTelemetry.tracer_provider.tracer("langfuse-rb", Langfuse::VERSION)
+      return tracer_provider.tracer(LANGFUSE_TRACER_NAME, Langfuse::VERSION) if setup_tracing_if_ready
+
+      warn_tracing_disabled_once
+      noop_tracer
     end
 
     # Creates an OpenTelemetry span (root or child)
@@ -513,6 +539,47 @@ module Langfuse
     def wrap_otel_span(otel_span, type_str, otel_tracer, attributes: nil)
       observation_class = OBSERVATION_TYPE_REGISTRY[type_str] || Span
       observation_class.new(otel_span, otel_tracer, attributes: attributes)
+    end
+
+    # rubocop:disable Naming/PredicateMethod
+    def setup_tracing_if_ready
+      return true if OtelSetup.initialized?
+      return false unless tracing_config_ready?
+
+      OtelSetup.setup(configuration)
+      true
+    end
+    # rubocop:enable Naming/PredicateMethod
+
+    def tracing_config_ready?
+      configured?(configuration.public_key) &&
+        configured?(configuration.secret_key) &&
+        configured?(configuration.base_url)
+    end
+
+    def configured?(value)
+      !value.nil? && !value.empty?
+    end
+
+    def warn_tracing_disabled_once
+      return if @tracing_disabled_warning_emitted
+
+      tracing_warning_mutex.synchronize do
+        return if @tracing_disabled_warning_emitted
+
+        configuration.logger.warn(
+          "Langfuse tracing is disabled until public_key, secret_key, and base_url are configured."
+        )
+        @tracing_disabled_warning_emitted = true
+      end
+    end
+
+    def tracing_warning_mutex
+      @tracing_warning_mutex ||= Mutex.new
+    end
+
+    def noop_tracer
+      @noop_tracer ||= OpenTelemetry::Trace::TracerProvider.new.tracer(LANGFUSE_TRACER_NAME, Langfuse::VERSION)
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/langfuse/config.rb
+++ b/lib/langfuse/config.rb
@@ -18,6 +18,7 @@ module Langfuse
   #     c.secret_key = "sk_..."
   #   end
   #
+  # rubocop:disable Metrics/ClassLength
   class Config
     # @return [String, nil] Langfuse public API key
     attr_accessor :public_key
@@ -73,6 +74,9 @@ module Langfuse
 
     # @return [String, nil] Default release identifier applied to new traces/observations
     attr_accessor :release
+
+    # @return [#call, nil] Callback that decides whether an ended span should export to Langfuse.
+    attr_accessor :should_export_span
 
     # @return [#call, nil] Mask callable applied to input, output, and metadata before serialization.
     #   Receives `data:` keyword argument. nil disables masking.
@@ -155,6 +159,7 @@ module Langfuse
       @job_queue = DEFAULT_JOB_QUEUE
       @environment = env_value("LANGFUSE_TRACING_ENVIRONMENT")
       @release = env_value("LANGFUSE_RELEASE") || detect_release_from_ci_env
+      @should_export_span = nil
       @mask = nil
       @logger = default_logger
 
@@ -183,6 +188,8 @@ module Langfuse
       validate_swr_config!
 
       validate_cache_backend!
+
+      validate_should_export_span!
 
       validate_mask!
     end
@@ -261,6 +268,12 @@ module Langfuse
       raise ConfigurationError, "mask must respond to #call"
     end
 
+    def validate_should_export_span!
+      return if should_export_span.nil? || should_export_span.respond_to?(:call)
+
+      raise ConfigurationError, "should_export_span must respond to #call"
+    end
+
     def detect_release_from_ci_env
       COMMON_RELEASE_ENV_KEYS.each do |key|
         value = env_value(key)
@@ -277,4 +290,5 @@ module Langfuse
       value
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/langfuse/otel_setup.rb
+++ b/lib/langfuse/otel_setup.rb
@@ -34,11 +34,15 @@ module Langfuse
         validate_tracing_config!(config)
         return existing_provider_for(config) if initialized?
 
+        candidate_provider = nil
         provider = nil
         created = false
-        provider = build_tracer_provider(config)
-        provider, created = publish_provider(provider, tracing_config_snapshot(config))
-        return existing_provider_for(config) unless created
+        candidate_provider = build_tracer_provider(config)
+        provider, created = publish_provider(candidate_provider, tracing_config_snapshot(config))
+        unless created
+          candidate_provider.shutdown(timeout: 30)
+          return existing_provider_for(config)
+        end
 
         configure_propagation(config)
         log_initialized(config)

--- a/lib/langfuse/otel_setup.rb
+++ b/lib/langfuse/otel_setup.rb
@@ -6,100 +6,71 @@ require "opentelemetry/trace/propagation/trace_context"
 require "base64"
 
 module Langfuse
-  # OpenTelemetry initialization and setup
-  #
-  # Handles configuration of the OTel SDK with Langfuse OTLP exporter
-  # when tracing is enabled.
-  #
+  # OpenTelemetry initialization and setup for Langfuse tracing.
+  # rubocop:disable Metrics/ModuleLength
   module OtelSetup
+    TRACING_CONFIG_FIELDS = %i[
+      public_key
+      secret_key
+      base_url
+      environment
+      release
+      should_export_span
+      tracing_async
+      batch_size
+      flush_interval
+    ].freeze
+    private_constant(:TRACING_CONFIG_FIELDS)
+
     class << self
-      # @return [OpenTelemetry::SDK::Trace::TracerProvider, nil] The configured tracer provider
+      # @return [OpenTelemetry::SDK::Trace::TracerProvider, nil] The configured internal tracer provider
       attr_reader :tracer_provider
 
-      # Initialize OpenTelemetry with Langfuse OTLP exporter
+      # Initialize Langfuse's internal tracer provider without mutating the global OTel provider.
       #
       # @param config [Langfuse::Config] The Langfuse configuration
-      # @return [void]
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # @return [OpenTelemetry::SDK::Trace::TracerProvider]
       def setup(config)
-        # Create OTLP exporter configured for Langfuse
-        exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(
-          endpoint: "#{config.base_url}/api/public/otel/v1/traces",
-          headers: build_headers(config.public_key, config.secret_key),
-          compression: "gzip"
-        )
+        validate_tracing_config!(config)
+        return existing_provider_for(config) if initialized?
 
-        # Create processor based on async configuration
-        # IMPORTANT: Always use BatchSpanProcessor (even in sync mode) to ensure spans
-        # are exported together, which allows proper parent-child relationship detection
-        processor = if config.tracing_async
-                      # Async: BatchSpanProcessor batches and sends in background
-                      OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-                        exporter,
-                        max_queue_size: config.batch_size * 2, # Buffer more than batch_size
-                        schedule_delay: config.flush_interval * 1000, # Convert seconds to milliseconds
-                        max_export_batch_size: config.batch_size
-                      )
-                    else
-                      # Sync: BatchSpanProcessor with minimal delay (flushes on force_flush)
-                      # This collects spans from the same trace and exports them together,
-                      # which is critical for correct parent_observation_id calculation
-                      OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-                        exporter,
-                        max_queue_size: config.batch_size * 2,
-                        schedule_delay: 60_000, # 60 seconds (relies on explicit force_flush)
-                        max_export_batch_size: config.batch_size
-                      )
-                    end
+        provider = nil
+        created = false
+        provider = build_tracer_provider(config)
+        provider, created = publish_provider(provider, tracing_config_snapshot(config))
+        return existing_provider_for(config) unless created
 
-        # Create TracerProvider with processor
-        @tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider.new
-        @tracer_provider.add_span_processor(processor)
-
-        # Add span processor for propagated attributes and env/release defaults
-        # This must be added AFTER the BatchSpanProcessor so it runs before export and can
-        # apply all attributes (propagated IDs, environment, release) to the spans being sent
-        span_processor = SpanProcessor.new(config: config)
-        @tracer_provider.add_span_processor(span_processor)
-
-        # Set as global tracer provider
-        OpenTelemetry.tracer_provider = @tracer_provider
-
-        # Configure W3C TraceContext propagator if not already set
-        if OpenTelemetry.propagation.is_a?(OpenTelemetry::Context::Propagation::NoopTextMapPropagator)
-          OpenTelemetry.propagation = OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator.new
-          config.logger.debug("Langfuse: Configured W3C TraceContext propagator")
-        else
-          config.logger.debug("Langfuse: Using existing propagator: #{OpenTelemetry.propagation.class}")
-        end
-
-        mode = config.tracing_async ? "async" : "sync"
-        config.logger.info("Langfuse tracing initialized with OpenTelemetry (#{mode} mode)")
+        configure_propagation(config)
+        log_initialized(config)
+        provider
+      rescue StandardError
+        rollback_provider(provider) if created
+        raise
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-      # Shutdown the tracer provider and flush any pending spans
+      # Shutdown the internal tracer provider and flush any pending spans.
       #
       # @param timeout [Integer] Timeout in seconds
       # @return [void]
       def shutdown(timeout: 30)
-        return unless @tracer_provider
-
-        @tracer_provider.shutdown(timeout: timeout)
-        @tracer_provider = nil
+        provider = nil
+        setup_mutex.synchronize do
+          provider = @tracer_provider
+          @tracer_provider = nil
+          @config_snapshot = nil
+        end
+        provider&.shutdown(timeout: timeout)
       end
 
-      # Force flush all pending spans
+      # Force flush all pending spans on the internal tracer provider.
       #
       # @param timeout [Integer] Timeout in seconds
       # @return [void]
       def force_flush(timeout: 30)
-        return unless @tracer_provider
-
-        @tracer_provider.force_flush(timeout: timeout)
+        @tracer_provider&.force_flush(timeout: timeout)
       end
 
-      # Check if OTel is initialized
+      # Check if Langfuse tracing has been initialized.
       #
       # @return [Boolean]
       def initialized?
@@ -108,18 +79,105 @@ module Langfuse
 
       private
 
-      # Build HTTP headers for Langfuse OTLP endpoint
-      #
-      # @param public_key [String] Langfuse public API key
-      # @param secret_key [String] Langfuse secret API key
-      # @return [Hash] HTTP headers with Basic Auth
+      def existing_provider_for(config)
+        snapshot = tracing_config_snapshot(config)
+        if @config_snapshot == snapshot
+          config.logger.debug("Langfuse tracing already initialized; reusing existing tracer provider")
+        else
+          config.logger.warn(
+            "Langfuse tracing is already initialized. Changes to #{TRACING_CONFIG_FIELDS.join(', ')} " \
+            "require Langfuse.reset! before they take effect."
+          )
+        end
+        @tracer_provider
+      end
+
+      def publish_provider(provider, snapshot)
+        created = false
+        current = nil
+
+        # This mutex only guards publication so setup never exposes a half-built provider.
+        setup_mutex.synchronize do
+          if @tracer_provider
+            current = @tracer_provider
+          else
+            @tracer_provider = provider
+            @config_snapshot = snapshot
+            current = provider
+            created = true
+          end
+        end
+
+        [current, created]
+      end
+
+      def rollback_provider(provider)
+        setup_mutex.synchronize do
+          return unless @tracer_provider.equal?(provider)
+
+          @tracer_provider = nil
+          @config_snapshot = nil
+        end
+        provider.shutdown(timeout: 1)
+      rescue StandardError
+        nil
+      end
+
+      def build_tracer_provider(config)
+        provider = OpenTelemetry::SDK::Trace::TracerProvider.new
+        provider.add_span_processor(
+          SpanProcessor.new(config: config, exporter: build_exporter(config))
+        )
+        provider
+      end
+
+      def build_exporter(config)
+        OpenTelemetry::Exporter::OTLP::Exporter.new(
+          endpoint: "#{config.base_url}/api/public/otel/v1/traces",
+          headers: build_headers(config.public_key, config.secret_key),
+          compression: "gzip"
+        )
+      end
+
+      def configure_propagation(config)
+        return unless OpenTelemetry.propagation.is_a?(OpenTelemetry::Context::Propagation::NoopTextMapPropagator)
+
+        OpenTelemetry.propagation = OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator.new
+        config.logger.debug("Langfuse: Configured W3C TraceContext propagator")
+      end
+
+      def log_initialized(config)
+        mode = config.tracing_async ? "async" : "sync"
+        config.logger.info("Langfuse tracing initialized with OpenTelemetry (#{mode} mode)")
+      end
+
+      def validate_tracing_config!(config)
+        raise ConfigurationError, "public_key is required" if blank?(config.public_key)
+        raise ConfigurationError, "secret_key is required" if blank?(config.secret_key)
+        raise ConfigurationError, "base_url cannot be empty" if blank?(config.base_url)
+        return if config.should_export_span.nil? || config.should_export_span.respond_to?(:call)
+
+        raise ConfigurationError, "should_export_span must respond to #call"
+      end
+
+      def tracing_config_snapshot(config)
+        TRACING_CONFIG_FIELDS.to_h { |field| [field, config.public_send(field)] }.freeze
+      end
+
+      def setup_mutex
+        @setup_mutex ||= Mutex.new
+      end
+
+      def blank?(value)
+        value.nil? || value.empty?
+      end
+
       def build_headers(public_key, secret_key)
         credentials = "#{public_key}:#{secret_key}"
         encoded = Base64.strict_encode64(credentials)
-        {
-          "Authorization" => "Basic #{encoded}"
-        }
+        { "Authorization" => "Basic #{encoded}" }
       end
     end
   end
+  # rubocop:enable Metrics/ModuleLength
 end

--- a/lib/langfuse/otel_setup.rb
+++ b/lib/langfuse/otel_setup.rb
@@ -2,7 +2,6 @@
 
 require "opentelemetry/sdk"
 require "opentelemetry/exporter/otlp"
-require "opentelemetry/trace/propagation/trace_context"
 require "base64"
 
 module Langfuse
@@ -26,7 +25,7 @@ module Langfuse
       # @return [OpenTelemetry::SDK::Trace::TracerProvider, nil] The configured internal tracer provider
       attr_reader :tracer_provider
 
-      # Initialize Langfuse's internal tracer provider without mutating the global OTel provider.
+      # Initialize Langfuse's internal tracer provider without mutating global OpenTelemetry state.
       #
       # @param config [Langfuse::Config] The Langfuse configuration
       # @return [OpenTelemetry::SDK::Trace::TracerProvider]
@@ -44,7 +43,6 @@ module Langfuse
           return existing_provider_for(config)
         end
 
-        configure_propagation(config)
         log_initialized(config)
         provider
       rescue StandardError
@@ -141,13 +139,6 @@ module Langfuse
           headers: build_headers(config.public_key, config.secret_key),
           compression: "gzip"
         )
-      end
-
-      def configure_propagation(config)
-        return unless OpenTelemetry.propagation.is_a?(OpenTelemetry::Context::Propagation::NoopTextMapPropagator)
-
-        OpenTelemetry.propagation = OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator.new
-        config.logger.debug("Langfuse: Configured W3C TraceContext propagator")
       end
 
       def log_initialized(config)

--- a/lib/langfuse/span_filter.rb
+++ b/lib/langfuse/span_filter.rb
@@ -18,6 +18,11 @@ module Langfuse
     "vllm"
   ].freeze
 
+  # Matched per span in the export path, so avoid allocating the dotted form each call.
+  KNOWN_LLM_INSTRUMENTATION_SCOPE_DOTTED_PREFIXES =
+    KNOWN_LLM_INSTRUMENTATION_SCOPE_PREFIXES.map { |prefix| "#{prefix}." }.freeze
+  private_constant :KNOWN_LLM_INSTRUMENTATION_SCOPE_DOTTED_PREFIXES
+
   class << self
     # Return whether the span was created by Langfuse's tracer.
     #
@@ -46,8 +51,10 @@ module Langfuse
       scope_name = instrumentation_scope_name(span)
       return false unless scope_name
 
-      KNOWN_LLM_INSTRUMENTATION_SCOPE_PREFIXES.any? do |prefix|
-        matches_scope_prefix?(scope_name, prefix)
+      return true if KNOWN_LLM_INSTRUMENTATION_SCOPE_PREFIXES.include?(scope_name)
+
+      KNOWN_LLM_INSTRUMENTATION_SCOPE_DOTTED_PREFIXES.any? do |dotted_prefix|
+        scope_name.start_with?(dotted_prefix)
       end
     end
 
@@ -69,10 +76,6 @@ module Langfuse
 
     def instrumentation_scope_name(span)
       span.instrumentation_scope&.name
-    end
-
-    def matches_scope_prefix?(scope_name, prefix)
-      scope_name == prefix || scope_name.start_with?("#{prefix}.")
     end
   end
 end

--- a/lib/langfuse/span_filter.rb
+++ b/lib/langfuse/span_filter.rb
@@ -60,6 +60,11 @@ module Langfuse
       is_langfuse_span(span) || is_genai_span(span) || is_known_llm_instrumentor(span)
     end
 
+    alias langfuse_span? is_langfuse_span
+    alias genai_span? is_genai_span
+    alias known_llm_instrumentor? is_known_llm_instrumentor
+    alias default_export_span? is_default_export_span
+
     private
 
     def instrumentation_scope_name(span)

--- a/lib/langfuse/span_filter.rb
+++ b/lib/langfuse/span_filter.rb
@@ -18,13 +18,12 @@ module Langfuse
     "vllm"
   ].freeze
 
-  # rubocop:disable Naming/PredicateMethod, Naming/PredicatePrefix
   class << self
     # Return whether the span was created by Langfuse's tracer.
     #
     # @param span [#instrumentation_scope] Span or span data to inspect
     # @return [Boolean]
-    def is_langfuse_span(span)
+    def langfuse_span?(span)
       instrumentation_scope_name(span) == LANGFUSE_TRACER_NAME
     end
 
@@ -32,7 +31,7 @@ module Langfuse
     #
     # @param span [#attributes] Span or span data to inspect
     # @return [Boolean]
-    def is_genai_span(span)
+    def genai_span?(span)
       attributes = span.attributes
       return false unless attributes
 
@@ -43,7 +42,7 @@ module Langfuse
     #
     # @param span [#instrumentation_scope] Span or span data to inspect
     # @return [Boolean]
-    def is_known_llm_instrumentor(span)
+    def known_llm_instrumentor?(span)
       scope_name = instrumentation_scope_name(span)
       return false unless scope_name
 
@@ -56,14 +55,15 @@ module Langfuse
     #
     # @param span [#instrumentation_scope, #attributes] Span or span data to inspect
     # @return [Boolean]
-    def is_default_export_span(span)
-      is_langfuse_span(span) || is_genai_span(span) || is_known_llm_instrumentor(span)
+    def default_export_span?(span)
+      langfuse_span?(span) || genai_span?(span) || known_llm_instrumentor?(span)
     end
 
-    alias langfuse_span? is_langfuse_span
-    alias genai_span? is_genai_span
-    alias known_llm_instrumentor? is_known_llm_instrumentor
-    alias default_export_span? is_default_export_span
+    # Cross-SDK parity keeps the `is_*` names public for compatibility.
+    alias is_langfuse_span langfuse_span?
+    alias is_genai_span genai_span?
+    alias is_known_llm_instrumentor known_llm_instrumentor?
+    alias is_default_export_span default_export_span?
 
     private
 
@@ -75,5 +75,4 @@ module Langfuse
       scope_name == prefix || scope_name.start_with?("#{prefix}.")
     end
   end
-  # rubocop:enable Naming/PredicateMethod, Naming/PredicatePrefix
 end

--- a/lib/langfuse/span_filter.rb
+++ b/lib/langfuse/span_filter.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Langfuse
+  # Instrumentation scope name used by module-level Langfuse tracing.
+  LANGFUSE_TRACER_NAME = "langfuse-rb"
+
+  # Conservative allowlist of instrumentation scope prefixes that clearly belong to LLM workflows.
+  KNOWN_LLM_INSTRUMENTATION_SCOPE_PREFIXES = [
+    LANGFUSE_TRACER_NAME,
+    "agent_framework",
+    "ai",
+    "haystack",
+    "langsmith",
+    "litellm",
+    "openinference",
+    "opentelemetry.instrumentation.anthropic",
+    "strands-agents",
+    "vllm"
+  ].freeze
+
+  # rubocop:disable Naming/PredicateMethod, Naming/PredicatePrefix
+  class << self
+    # Return whether the span was created by Langfuse's tracer.
+    #
+    # @param span [#instrumentation_scope] Span or span data to inspect
+    # @return [Boolean]
+    def is_langfuse_span(span)
+      instrumentation_scope_name(span) == LANGFUSE_TRACER_NAME
+    end
+
+    # Return whether the span contains `gen_ai.*` attributes.
+    #
+    # @param span [#attributes] Span or span data to inspect
+    # @return [Boolean]
+    def is_genai_span(span)
+      attributes = span.attributes
+      return false unless attributes
+
+      attributes.keys.any? { |key| key.is_a?(String) && key.start_with?("gen_ai.") }
+    end
+
+    # Return whether the span came from a known LLM instrumentation scope.
+    #
+    # @param span [#instrumentation_scope] Span or span data to inspect
+    # @return [Boolean]
+    def is_known_llm_instrumentor(span)
+      scope_name = instrumentation_scope_name(span)
+      return false unless scope_name
+
+      KNOWN_LLM_INSTRUMENTATION_SCOPE_PREFIXES.any? do |prefix|
+        matches_scope_prefix?(scope_name, prefix)
+      end
+    end
+
+    # Return whether a span should be exported when no custom filter is configured.
+    #
+    # @param span [#instrumentation_scope, #attributes] Span or span data to inspect
+    # @return [Boolean]
+    def is_default_export_span(span)
+      is_langfuse_span(span) || is_genai_span(span) || is_known_llm_instrumentor(span)
+    end
+
+    private
+
+    def instrumentation_scope_name(span)
+      span.instrumentation_scope&.name
+    end
+
+    def matches_scope_prefix?(scope_name, prefix)
+      scope_name == prefix || scope_name.start_with?("#{prefix}.")
+    end
+  end
+  # rubocop:enable Naming/PredicateMethod, Naming/PredicatePrefix
+end

--- a/lib/langfuse/span_processor.rb
+++ b/lib/langfuse/span_processor.rb
@@ -46,8 +46,13 @@ module Langfuse
 
     private
 
+    # Sync mode relies on explicit `force_flush` calls, so keep the background flush
+    # interval long enough that it rarely fires on its own.
+    SYNC_SCHEDULE_DELAY_MS = 60_000
+    private_constant :SYNC_SCHEDULE_DELAY_MS
+
     def schedule_delay_for(config)
-      config.tracing_async ? config.flush_interval * 1000 : 60_000
+      config.tracing_async ? config.flush_interval * 1000 : SYNC_SCHEDULE_DELAY_MS
     end
 
     def build_default_trace_attributes(config)

--- a/lib/langfuse/span_processor.rb
+++ b/lib/langfuse/span_processor.rb
@@ -12,7 +12,7 @@ module Langfuse
     def initialize(config:, exporter:)
       @logger = config.logger
       @default_trace_attributes = build_default_trace_attributes(config).freeze
-      @should_export_span = config.should_export_span || Langfuse.method(:is_default_export_span)
+      @should_export_span = config.should_export_span || Langfuse.method(:default_export_span?)
 
       super(
         exporter,

--- a/lib/langfuse/span_processor.rb
+++ b/lib/langfuse/span_processor.rb
@@ -3,22 +3,26 @@
 require "opentelemetry/sdk"
 
 module Langfuse
-  # Span processor that applies default and propagated trace attributes on new spans.
-  #
-  # On span start, this processor first applies configured trace defaults
-  # (environment/release), then overlays attributes propagated in OpenTelemetry
-  # context (user/session/metadata/tags/version). This ensures consistent
-  # trace dimensions while still honoring per-request propagation.
+  # Batch span processor that owns Langfuse's enrichment and export filtering.
   #
   # @api private
-  class SpanProcessor < OpenTelemetry::SDK::Trace::SpanProcessor
-    # @param config [Langfuse::Config, nil] SDK configuration used to build trace defaults
-    def initialize(config: Langfuse.configuration)
+  class SpanProcessor < OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor
+    # @param config [Langfuse::Config] SDK configuration used for defaults and filtering
+    # @param exporter [#export, #force_flush, #shutdown] Span exporter used by the batch processor
+    def initialize(config:, exporter:)
+      @logger = config.logger
       @default_trace_attributes = build_default_trace_attributes(config).freeze
-      super()
+      @should_export_span = config.should_export_span || Langfuse.method(:is_default_export_span)
+
+      super(
+        exporter,
+        max_queue_size: config.batch_size * 2,
+        schedule_delay: schedule_delay_for(config),
+        max_export_batch_size: config.batch_size
+      )
     end
 
-    # Called when a span starts
+    # Apply Langfuse trace defaults and propagated attributes before a span records work.
     #
     # @param span [OpenTelemetry::SDK::Trace::Span] The span that started
     # @param parent_context [OpenTelemetry::Context] The parent context
@@ -30,41 +34,23 @@ module Langfuse
       apply_attributes(span, propagated_attributes(parent_context))
     end
 
-    # Called when a span ends
+    # Drop spans when the export filter rejects them or raises.
     #
     # @param span [OpenTelemetry::SDK::Trace::Span] The span that ended
     # @return [void]
     def on_finish(span)
-      # No-op - we don't need to do anything when spans finish
-    end
+      return unless should_export_span?(span)
 
-    # Shutdown the processor
-    #
-    # @param timeout [Integer, nil] Timeout in seconds (unused for this processor)
-    # @return [Integer] Always returns 0 (no timeout needed for no-op)
-    def shutdown(timeout: nil)
-      # No-op - nothing to clean up
-      # Return 0 to match OpenTelemetry SDK expectation (it finds max timeout from processors)
-      _ = timeout # Suppress unused argument warning
-      0
-    end
-
-    # Force flush (no-op for this processor)
-    #
-    # @param timeout [Integer, nil] Timeout in seconds (unused for this processor)
-    # @return [Integer] Always returns 0 (no timeout needed for no-op)
-    def force_flush(timeout: nil)
-      # No-op - nothing to flush
-      # Return 0 to match OpenTelemetry SDK expectation (it finds max timeout from processors)
-      _ = timeout # Suppress unused argument warning
-      0
+      super
     end
 
     private
 
-    def build_default_trace_attributes(config)
-      return {} unless config
+    def schedule_delay_for(config)
+      config.tracing_async ? config.flush_interval * 1000 : 60_000
+    end
 
+    def build_default_trace_attributes(config)
       OtelAttributes.create_trace_attributes(
         { environment: config.environment, release: config.release }
       )
@@ -78,6 +64,16 @@ module Langfuse
 
     def apply_attributes(span, attributes)
       attributes.each { |key, value| span.set_attribute(key, value) }
+    end
+
+    def should_export_span?(span)
+      @should_export_span.call(span)
+    rescue StandardError => e
+      @logger.error(
+        "Langfuse tracing dropped span '#{span.name}' because should_export_span raised: " \
+        "#{e.class}: #{e.message}"
+      )
+      false
     end
   end
 end

--- a/spec/langfuse/config_spec.rb
+++ b/spec/langfuse/config_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Langfuse::Config do
       expect(config.cache_stale_while_revalidate).to be false
       expect(config.cache_stale_ttl).to eq(0) # Defaults to 0 (SWR disabled)
       expect(config.cache_refresh_threads).to eq(5)
+      expect(config.should_export_span).to be_nil
     end
 
     it "reads from environment variables" do
@@ -180,6 +181,23 @@ RSpec.describe Langfuse::Config do
           Langfuse::ConfigurationError,
           "timeout must be positive"
         )
+      end
+    end
+
+    context "when should_export_span is invalid" do
+      it "raises ConfigurationError when it does not respond to #call" do
+        config.should_export_span = "not callable"
+
+        expect { config.validate! }.to raise_error(
+          Langfuse::ConfigurationError,
+          "should_export_span must respond to #call"
+        )
+      end
+
+      it "accepts callables" do
+        config.should_export_span = ->(_span) { true }
+
+        expect { config.validate! }.not_to raise_error
       end
     end
 

--- a/spec/langfuse/otel_setup_spec.rb
+++ b/spec/langfuse/otel_setup_spec.rb
@@ -3,32 +3,26 @@
 require "spec_helper"
 
 RSpec.describe Langfuse::OtelSetup do
-  let(:public_key) { "pk_test_123" }
-  let(:secret_key) { "sk_test_456" }
-  let(:base_url) { "https://api.langfuse.test" }
-
+  let(:logger) { instance_double(Logger, info: nil, debug: nil, warn: nil) }
+  let(:exporter) { OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new }
   let(:config) do
     Langfuse::Config.new do |c|
-      c.public_key = public_key
-      c.secret_key = secret_key
-      c.base_url = base_url
-      c.tracing_async = true
-      c.batch_size = 50
-      c.flush_interval = 10
+      c.public_key = "pk_test_123"
+      c.secret_key = "sk_test_456"
+      c.base_url = "https://api.langfuse.test"
+      c.tracing_async = false
+      c.batch_size = 10
+      c.flush_interval = 1
+      c.logger = logger
     end
   end
 
   before do
-    # Reset OTel setup before each test
     described_class.shutdown(timeout: 1) if described_class.initialized?
-
-    # Stub OTLP endpoint
-    stub_request(:post, "#{base_url}/api/public/otel/v1/traces")
-      .to_return(status: 200, body: "", headers: {})
+    allow(described_class).to receive(:build_exporter).and_return(exporter)
   end
 
   after do
-    # Clean up after each test
     described_class.shutdown(timeout: 1) if described_class.initialized?
   end
 
@@ -36,178 +30,155 @@ RSpec.describe Langfuse::OtelSetup do
     it "initializes the tracer provider" do
       described_class.setup(config)
 
-      expect(described_class.tracer_provider).not_to be_nil
+      expect(described_class.tracer_provider).to be_a(OpenTelemetry::SDK::Trace::TracerProvider)
       expect(described_class.initialized?).to be true
     end
 
-    it "sets the global tracer provider" do
+    it "does not mutate the global tracer provider" do
+      original_global_provider = OpenTelemetry.tracer_provider
+
       described_class.setup(config)
 
-      expect(OpenTelemetry.tracer_provider).to eq(described_class.tracer_provider)
+      expect(OpenTelemetry.tracer_provider).to eq(original_global_provider)
     end
 
-    it "configures W3C TraceContext propagator when none is set" do
+    it "configures W3C TraceContext propagation when none is set" do
       described_class.setup(config)
 
       expect(OpenTelemetry.propagation).to be_a(OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator)
     end
 
-    it "does not overwrite existing propagator" do
-      custom_propagator = OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator.new
-      OpenTelemetry.propagation = custom_propagator
+    it "reuses the existing provider for identical tracing config" do
+      provider = described_class.setup(config)
 
-      described_class.setup(config)
-
-      expect(OpenTelemetry.propagation).to eq(custom_propagator)
+      expect(logger).to receive(:debug).with(/reusing existing tracer provider/)
+      expect(described_class.setup(config)).to equal(provider)
     end
 
-    it "logs initialization message" do
-      expect(config.logger).to receive(:info).with(/Langfuse tracing initialized/)
+    it "warns and keeps the existing provider when tracing config changes" do
+      provider = described_class.setup(config)
+      config.environment = "staging"
 
-      described_class.setup(config)
+      expect(logger).to receive(:warn).with(/require Langfuse.reset!/)
+      expect(described_class.setup(config)).to equal(provider)
     end
 
-    context "with async mode enabled" do
-      before do
-        config.tracing_async = true
-      end
+    it "validates should_export_span in setup" do
+      config.should_export_span = "bad"
 
-      it "logs async mode" do
-        expect(config.logger).to receive(:info).with(/async mode/)
-
-        described_class.setup(config)
-      end
-
-      it "creates a BatchSpanProcessor" do
-        described_class.setup(config)
-
-        # Verify tracer can create spans (indicating processor is working)
-        tracer = OpenTelemetry.tracer_provider.tracer("test")
-        expect { tracer.in_span("test") { |span| } }.not_to raise_error
-      end
-    end
-
-    context "with async mode disabled" do
-      before do
-        config.tracing_async = false
-      end
-
-      it "logs sync mode" do
-        expect(config.logger).to receive(:info).with(/sync mode/)
-
-        described_class.setup(config)
-      end
-
-      it "creates a SimpleSpanProcessor" do
-        described_class.setup(config)
-
-        # Verify tracer can create spans (indicating processor is working)
-        tracer = OpenTelemetry.tracer_provider.tracer("test")
-        expect { tracer.in_span("test") { |span| } }.not_to raise_error
-      end
+      expect { described_class.setup(config) }.to raise_error(
+        Langfuse::ConfigurationError,
+        "should_export_span must respond to #call"
+      )
     end
   end
 
   describe ".shutdown" do
-    context "when initialized" do
-      before do
-        described_class.setup(config)
-      end
-
-      it "shuts down the tracer provider" do
-        described_class.shutdown(timeout: 1)
-
-        expect(described_class.tracer_provider).to be_nil
-        expect(described_class.initialized?).to be false
-      end
-
-      it "accepts a custom timeout" do
-        expect { described_class.shutdown(timeout: 5) }.not_to raise_error
-      end
-    end
-
-    context "when not initialized" do
-      it "does not raise an error" do
-        expect { described_class.shutdown }.not_to raise_error
-      end
+    it "is safe before initialization" do
+      expect { described_class.shutdown(timeout: 1) }.not_to raise_error
     end
   end
 
   describe ".force_flush" do
-    context "when initialized" do
-      before do
-        described_class.setup(config)
-      end
-
-      it "flushes pending spans" do
-        expect { described_class.force_flush(timeout: 1) }.not_to raise_error
-      end
-
-      it "accepts a custom timeout" do
-        expect { described_class.force_flush(timeout: 5) }.not_to raise_error
-      end
-    end
-
-    context "when not initialized" do
-      it "does not raise an error" do
-        expect { described_class.force_flush }.not_to raise_error
-      end
+    it "is safe before initialization" do
+      expect { described_class.force_flush(timeout: 1) }.not_to raise_error
     end
   end
 
-  describe ".initialized?" do
-    it "returns false when not initialized" do
-      expect(described_class.initialized?).to be false
-    end
-
-    it "returns true when initialized" do
-      described_class.setup(config)
-
-      expect(described_class.initialized?).to be true
-    end
-
-    it "returns false after shutdown" do
-      described_class.setup(config)
-      described_class.shutdown(timeout: 1)
-
-      expect(described_class.initialized?).to be false
-    end
-  end
-
-  describe "integration with Langfuse.configure" do
-    it "auto-initializes OTel" do
+  describe "lazy module-level setup" do
+    it "does not initialize tracing during Langfuse.configure" do
       Langfuse.configure do |c|
-        c.public_key = public_key
-        c.secret_key = secret_key
-        c.base_url = base_url
+        c.public_key = config.public_key
+        c.secret_key = config.secret_key
+        c.base_url = config.base_url
+        c.logger = logger
       end
 
-      expect(described_class.initialized?).to be true
+      expect(described_class.initialized?).to be false
+    end
+
+    it "raises from Langfuse.tracer_provider when tracing is not ready" do
+      Langfuse.reset!
+      Langfuse.configure do |c|
+        c.public_key = nil
+        c.secret_key = nil
+        c.base_url = nil
+        c.logger = logger
+      end
+
+      expect { Langfuse.tracer_provider }.to raise_error(
+        Langfuse::ConfigurationError,
+        /Langfuse tracing is disabled/
+      )
+    end
+
+    it "initializes once when Langfuse.tracer_provider is called concurrently" do
+      Langfuse.reset!
+      Langfuse.configure do |c|
+        c.public_key = config.public_key
+        c.secret_key = config.secret_key
+        c.base_url = config.base_url
+        c.logger = logger
+      end
+
+      providers = Queue.new
+      threads = 5.times.map do
+        Thread.new { providers << Langfuse.tracer_provider }
+      end
+      threads.each(&:join)
+
+      resolved = 5.times.map { providers.pop }
+      expect(resolved.map(&:object_id).uniq.length).to eq(1)
     end
   end
 
-  describe "integration with global tracer" do
+  describe "export behavior" do
     before do
+      Langfuse.reset!
       Langfuse.configure do |c|
-        c.public_key = public_key
-        c.secret_key = secret_key
-        c.base_url = base_url
-        c.tracing_async = false # Sync mode for predictable testing
+        c.public_key = config.public_key
+        c.secret_key = config.secret_key
+        c.base_url = config.base_url
+        c.tracing_async = false
+        c.batch_size = 10
+        c.flush_interval = 1
+        c.logger = logger
       end
     end
 
-    it "sends spans to Langfuse API" do
-      # Create a span directly using OpenTelemetry
-      otel_tracer = OpenTelemetry.tracer_provider.tracer("test")
-      otel_tracer.in_span("test-span") do |_span|
-        # Span is automatically sent when it ends
-      end
-
-      # Force flush to send immediately
+    it "exports Langfuse-created spans without exporting ambient global spans" do
+      OpenTelemetry.tracer_provider.tracer("dalli").start_span("cache-span").finish
+      span = Langfuse.observe("langfuse-span")
+      span.end
       Langfuse.force_flush(timeout: 1)
 
-      # Verify OTLP endpoint was called
-      expect(WebMock).to have_requested(:post, "#{base_url}/api/public/otel/v1/traces").at_least_once
+      expect(exporter.finished_spans.map(&:name)).to eq(["langfuse-span"])
+    end
+
+    it "exports known LLM scopes after explicit global installation" do
+      OpenTelemetry.tracer_provider = Langfuse.tracer_provider
+      OpenTelemetry.tracer_provider.tracer("langsmith.client").start_span("global-span").finish
+      Langfuse.force_flush(timeout: 1)
+
+      expect(exporter.finished_spans.map(&:name)).to eq(["global-span"])
+    end
+
+    it "allows custom filters to drop globally installed spans again" do
+      Langfuse.reset!
+      Langfuse.configure do |c|
+        c.public_key = config.public_key
+        c.secret_key = config.secret_key
+        c.base_url = config.base_url
+        c.tracing_async = false
+        c.should_export_span = ->(_span) { false }
+        c.logger = logger
+      end
+
+      OpenTelemetry.tracer_provider = Langfuse.tracer_provider
+      OpenTelemetry.tracer_provider.tracer("langsmith.client").start_span("global-span").finish
+      Langfuse.force_flush(timeout: 1)
+
+      expect(exporter.finished_spans).to be_empty
     end
   end
 end

--- a/spec/langfuse/otel_setup_spec.rb
+++ b/spec/langfuse/otel_setup_spec.rb
@@ -42,10 +42,12 @@ RSpec.describe Langfuse::OtelSetup do
       expect(OpenTelemetry.tracer_provider).to eq(original_global_provider)
     end
 
-    it "configures W3C TraceContext propagation when none is set" do
+    it "does not mutate the global propagator" do
+      original_global_propagation = OpenTelemetry.propagation
+
       described_class.setup(config)
 
-      expect(OpenTelemetry.propagation).to be_a(OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator)
+      expect(OpenTelemetry.propagation).to eq(original_global_propagation)
     end
 
     it "reuses the existing provider for identical tracing config" do

--- a/spec/langfuse/otel_setup_spec.rb
+++ b/spec/langfuse/otel_setup_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe Langfuse::OtelSetup do
       expect(described_class.setup(config)).to equal(provider)
     end
 
+    it "shuts down unpublished providers lost in the setup race" do
+      candidate_provider = instance_double(OpenTelemetry::SDK::Trace::TracerProvider, shutdown: nil)
+      existing_provider = instance_double(OpenTelemetry::SDK::Trace::TracerProvider)
+
+      allow(described_class).to receive_messages(
+        build_tracer_provider: candidate_provider,
+        publish_provider: [existing_provider, false],
+        existing_provider_for: existing_provider
+      )
+
+      expect(candidate_provider).to receive(:shutdown).with(timeout: 30)
+      expect(described_class.setup(config)).to equal(existing_provider)
+    end
+
     it "validates should_export_span in setup" do
       config.should_export_span = "bad"
 

--- a/spec/langfuse/span_filter_spec.rb
+++ b/spec/langfuse/span_filter_spec.rb
@@ -8,71 +8,71 @@ RSpec.describe "Langfuse span filters" do
     Struct.new(:instrumentation_scope, :attributes).new(scope, attributes)
   end
 
-  describe ".is_langfuse_span" do
+  describe ".langfuse_span?" do
     it "matches Langfuse spans" do
-      expect(Langfuse.is_langfuse_span(make_span(scope_name: Langfuse::LANGFUSE_TRACER_NAME))).to be true
+      expect(Langfuse.langfuse_span?(make_span(scope_name: Langfuse::LANGFUSE_TRACER_NAME))).to be true
     end
 
     it "rejects other scopes" do
-      expect(Langfuse.is_langfuse_span(make_span(scope_name: "other-lib"))).to be false
+      expect(Langfuse.langfuse_span?(make_span(scope_name: "other-lib"))).to be false
     end
 
-    it "exposes an idiomatic predicate alias" do
-      expect(Langfuse.langfuse_span?(make_span(scope_name: Langfuse::LANGFUSE_TRACER_NAME))).to be true
+    it "keeps the compatibility alias" do
+      expect(Langfuse.is_langfuse_span(make_span(scope_name: Langfuse::LANGFUSE_TRACER_NAME))).to be true
     end
   end
 
-  describe ".is_genai_span" do
+  describe ".genai_span?" do
     it "matches gen_ai attributes" do
-      expect(Langfuse.is_genai_span(make_span(attributes: { "gen_ai.system" => "openai" }))).to be true
+      expect(Langfuse.genai_span?(make_span(attributes: { "gen_ai.system" => "openai" }))).to be true
     end
 
     it "rejects non gen_ai attributes" do
-      expect(Langfuse.is_genai_span(make_span(attributes: { "http.method" => "GET" }))).to be false
+      expect(Langfuse.genai_span?(make_span(attributes: { "http.method" => "GET" }))).to be false
     end
 
-    it "exposes an idiomatic predicate alias" do
-      expect(Langfuse.genai_span?(make_span(attributes: { "gen_ai.system" => "openai" }))).to be true
+    it "keeps the compatibility alias" do
+      expect(Langfuse.is_genai_span(make_span(attributes: { "gen_ai.system" => "openai" }))).to be true
     end
   end
 
-  describe ".is_known_llm_instrumentor" do
+  describe ".known_llm_instrumentor?" do
     it "matches exact prefixes" do
-      expect(Langfuse.is_known_llm_instrumentor(make_span(scope_name: "ai"))).to be true
+      expect(Langfuse.known_llm_instrumentor?(make_span(scope_name: "ai"))).to be true
     end
 
     it "matches descendant scopes" do
-      expect(Langfuse.is_known_llm_instrumentor(make_span(scope_name: "langsmith.client"))).to be true
+      expect(Langfuse.known_llm_instrumentor?(make_span(scope_name: "langsmith.client"))).to be true
     end
 
     it "rejects unrelated scopes" do
-      expect(Langfuse.is_known_llm_instrumentor(make_span(scope_name: "dalli"))).to be false
+      expect(Langfuse.known_llm_instrumentor?(make_span(scope_name: "dalli"))).to be false
     end
 
-    it "exposes an idiomatic predicate alias" do
-      expect(Langfuse.known_llm_instrumentor?(make_span(scope_name: "langsmith.client"))).to be true
+    it "keeps the compatibility alias" do
+      expect(Langfuse.is_known_llm_instrumentor(make_span(scope_name: "langsmith.client"))).to be true
     end
   end
 
-  describe ".is_default_export_span" do
+  describe ".default_export_span?" do
     it "keeps Langfuse spans" do
-      expect(Langfuse.is_default_export_span(make_span(scope_name: Langfuse::LANGFUSE_TRACER_NAME))).to be true
+      expect(Langfuse.default_export_span?(make_span(scope_name: Langfuse::LANGFUSE_TRACER_NAME))).to be true
     end
 
     it "keeps gen_ai spans" do
-      expect(Langfuse.is_default_export_span(make_span(attributes: { "gen_ai.request.model" => "gpt-4" }))).to be true
+      expect(Langfuse.default_export_span?(make_span(attributes: { "gen_ai.request.model" => "gpt-4" }))).to be true
     end
 
     it "keeps known LLM instrumentation scopes" do
-      expect(Langfuse.is_default_export_span(make_span(scope_name: "openinference.instrumentation"))).to be true
+      expect(Langfuse.default_export_span?(make_span(scope_name: "openinference.instrumentation"))).to be true
     end
 
     it "drops unrelated spans" do
-      expect(Langfuse.is_default_export_span(make_span(scope_name: "dalli"))).to be false
+      expect(Langfuse.default_export_span?(make_span(scope_name: "dalli"))).to be false
     end
 
-    it "exposes an idiomatic predicate alias" do
-      expect(Langfuse.default_export_span?(make_span(scope_name: "openinference.instrumentation"))).to be true
+    it "keeps the compatibility alias" do
+      expect(Langfuse.is_default_export_span(make_span(scope_name: "openinference.instrumentation"))).to be true
     end
   end
 end

--- a/spec/langfuse/span_filter_spec.rb
+++ b/spec/langfuse/span_filter_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Langfuse span filters" do
+  def make_span(scope_name: nil, attributes: nil)
+    scope = scope_name ? Struct.new(:name).new(scope_name) : nil
+    Struct.new(:instrumentation_scope, :attributes).new(scope, attributes)
+  end
+
+  describe ".is_langfuse_span" do
+    it "matches Langfuse spans" do
+      expect(Langfuse.is_langfuse_span(make_span(scope_name: Langfuse::LANGFUSE_TRACER_NAME))).to be true
+    end
+
+    it "rejects other scopes" do
+      expect(Langfuse.is_langfuse_span(make_span(scope_name: "other-lib"))).to be false
+    end
+  end
+
+  describe ".is_genai_span" do
+    it "matches gen_ai attributes" do
+      expect(Langfuse.is_genai_span(make_span(attributes: { "gen_ai.system" => "openai" }))).to be true
+    end
+
+    it "rejects non gen_ai attributes" do
+      expect(Langfuse.is_genai_span(make_span(attributes: { "http.method" => "GET" }))).to be false
+    end
+  end
+
+  describe ".is_known_llm_instrumentor" do
+    it "matches exact prefixes" do
+      expect(Langfuse.is_known_llm_instrumentor(make_span(scope_name: "ai"))).to be true
+    end
+
+    it "matches descendant scopes" do
+      expect(Langfuse.is_known_llm_instrumentor(make_span(scope_name: "langsmith.client"))).to be true
+    end
+
+    it "rejects unrelated scopes" do
+      expect(Langfuse.is_known_llm_instrumentor(make_span(scope_name: "dalli"))).to be false
+    end
+  end
+
+  describe ".is_default_export_span" do
+    it "keeps Langfuse spans" do
+      expect(Langfuse.is_default_export_span(make_span(scope_name: Langfuse::LANGFUSE_TRACER_NAME))).to be true
+    end
+
+    it "keeps gen_ai spans" do
+      expect(Langfuse.is_default_export_span(make_span(attributes: { "gen_ai.request.model" => "gpt-4" }))).to be true
+    end
+
+    it "keeps known LLM instrumentation scopes" do
+      expect(Langfuse.is_default_export_span(make_span(scope_name: "openinference.instrumentation"))).to be true
+    end
+
+    it "drops unrelated spans" do
+      expect(Langfuse.is_default_export_span(make_span(scope_name: "dalli"))).to be false
+    end
+  end
+end

--- a/spec/langfuse/span_filter_spec.rb
+++ b/spec/langfuse/span_filter_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe "Langfuse span filters" do
     it "rejects other scopes" do
       expect(Langfuse.is_langfuse_span(make_span(scope_name: "other-lib"))).to be false
     end
+
+    it "exposes an idiomatic predicate alias" do
+      expect(Langfuse.langfuse_span?(make_span(scope_name: Langfuse::LANGFUSE_TRACER_NAME))).to be true
+    end
   end
 
   describe ".is_genai_span" do
@@ -25,6 +29,10 @@ RSpec.describe "Langfuse span filters" do
 
     it "rejects non gen_ai attributes" do
       expect(Langfuse.is_genai_span(make_span(attributes: { "http.method" => "GET" }))).to be false
+    end
+
+    it "exposes an idiomatic predicate alias" do
+      expect(Langfuse.genai_span?(make_span(attributes: { "gen_ai.system" => "openai" }))).to be true
     end
   end
 
@@ -39,6 +47,10 @@ RSpec.describe "Langfuse span filters" do
 
     it "rejects unrelated scopes" do
       expect(Langfuse.is_known_llm_instrumentor(make_span(scope_name: "dalli"))).to be false
+    end
+
+    it "exposes an idiomatic predicate alias" do
+      expect(Langfuse.known_llm_instrumentor?(make_span(scope_name: "langsmith.client"))).to be true
     end
   end
 
@@ -57,6 +69,10 @@ RSpec.describe "Langfuse span filters" do
 
     it "drops unrelated spans" do
       expect(Langfuse.is_default_export_span(make_span(scope_name: "dalli"))).to be false
+    end
+
+    it "exposes an idiomatic predicate alias" do
+      expect(Langfuse.default_export_span?(make_span(scope_name: "openinference.instrumentation"))).to be true
     end
   end
 end

--- a/spec/langfuse/span_processor_spec.rb
+++ b/spec/langfuse/span_processor_spec.rb
@@ -3,127 +3,105 @@
 require "spec_helper"
 
 RSpec.describe Langfuse::SpanProcessor do
-  let(:processor) { described_class.new }
-  let(:tracer_provider) { OpenTelemetry::SDK::Trace::TracerProvider.new }
-  let(:tracer) { tracer_provider.tracer("test") }
+  let(:logger) { instance_double(Logger, error: nil) }
+  let(:exporter) { OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new }
+  let(:config) do
+    Langfuse::Config.new do |c|
+      c.public_key = "pk_test"
+      c.secret_key = "sk_test"
+      c.base_url = "https://cloud.langfuse.com"
+      c.environment = "production"
+      c.release = "release-123"
+      c.tracing_async = false
+      c.batch_size = 10
+      c.flush_interval = 1
+      c.logger = logger
+    end
+  end
+  let(:processor) { described_class.new(config: config, exporter: exporter) }
+  let(:tracer_provider) do
+    OpenTelemetry::SDK::Trace::TracerProvider.new.tap do |provider|
+      provider.add_span_processor(processor)
+    end
+  end
+
+  def exported_span_names
+    tracer_provider.force_flush(timeout: 1)
+    exporter.finished_spans.map(&:name)
+  end
 
   describe "#on_start" do
     it "sets configured environment and release defaults on new spans" do
-      config = instance_double(Langfuse::Config, environment: "production", release: "release-123")
-      custom_processor = described_class.new(config: config)
-      span = tracer.start_span("test-span")
-      parent_context = OpenTelemetry::Context.current
+      span = tracer_provider.tracer("test").start_span("test-span")
 
-      custom_processor.on_start(span, parent_context)
-
-      attrs = span.attributes
-      expect(attrs["langfuse.environment"]).to eq("production")
-      expect(attrs["langfuse.release"]).to eq("release-123")
-
-      span.finish
-    end
-
-    it "does not set environment/release defaults when they are nil" do
-      config = instance_double(Langfuse::Config, environment: nil, release: nil)
-      custom_processor = described_class.new(config: config)
-      span = tracer.start_span("test-span")
-      parent_context = OpenTelemetry::Context.current
-
-      custom_processor.on_start(span, parent_context)
-
-      attrs = span.attributes
-      expect(attrs).not_to have_key("langfuse.environment")
-      expect(attrs).not_to have_key("langfuse.release")
-
-      span.finish
+      expect(span.attributes["langfuse.environment"]).to eq("production")
+      expect(span.attributes["langfuse.release"]).to eq("release-123")
     end
 
     it "sets propagated attributes on new spans" do
       span = nil
 
       Langfuse::Propagation.propagate_attributes(user_id: "user_123", session_id: "session_abc") do
-        span = tracer.start_span("test-span")
-        # Simulate what the span processor does
-        parent_context = OpenTelemetry::Context.current
-        processor.on_start(span, parent_context)
+        span = tracer_provider.tracer("test").start_span("test-span")
       end
 
-      expect(span).not_to be_nil
-      expect(span.recording?).to be true
-
-      attrs = span.attributes
-      expect(attrs["user.id"]).to eq("user_123")
-      expect(attrs["session.id"]).to eq("session_abc")
-
-      span.finish
-    end
-
-    it "does not set attributes on non-recording spans" do
-      # Create a non-recording span
-      span_context = OpenTelemetry::Trace::SpanContext.new(
-        trace_id: OpenTelemetry::Trace.generate_trace_id,
-        span_id: OpenTelemetry::Trace.generate_span_id,
-        trace_flags: OpenTelemetry::Trace::TraceFlags::SAMPLED
-      )
-      non_recording_span = OpenTelemetry::Trace.non_recording_span(span_context)
-      context = OpenTelemetry::Trace.context_with_span(non_recording_span)
-
-      # Create a recording span but with non-recording parent context
-      span = tracer.start_span("test-span")
-
-      # Should not error even with non-recording span in context
-      expect { processor.on_start(span, context) }.not_to raise_error
-
-      span.finish
-    end
-
-    it "handles spans with no propagated attributes" do
-      span = tracer.start_span("test-span")
-      context = OpenTelemetry::Context.current
-
-      # Should not error when no attributes are in context
-      expect { processor.on_start(span, context) }.not_to raise_error
-
-      span.finish
-    end
-
-    it "sets metadata attributes correctly" do
-      span = nil
-
-      Langfuse::Propagation.propagate_attributes(metadata: { environment: "production", region: "us-east" }) do
-        span = tracer.start_span("test-span")
-        parent_context = OpenTelemetry::Context.current
-        processor.on_start(span, parent_context)
-      end
-
-      attrs = span.attributes
-      expect(attrs["langfuse.trace.metadata.environment"]).to eq("production")
-      expect(attrs["langfuse.trace.metadata.region"]).to eq("us-east")
-
-      span.finish
-    end
-
-    it "sets tags correctly" do
-      span = nil
-
-      Langfuse::Propagation.propagate_attributes(tags: %w[production api-v2]) do
-        span = tracer.start_span("test-span")
-        parent_context = OpenTelemetry::Context.current
-        processor.on_start(span, parent_context)
-      end
-
-      attrs = span.attributes
-      expect(attrs["langfuse.trace.tags"]).to contain_exactly("production", "api-v2")
-
-      span.finish
+      expect(span.attributes["user.id"]).to eq("user_123")
+      expect(span.attributes["session.id"]).to eq("session_abc")
     end
   end
 
   describe "#on_finish" do
-    it "does not error" do
-      span = tracer.start_span("test-span")
-      expect { processor.on_finish(span) }.not_to raise_error
+    it "exports Langfuse spans by default" do
+      tracer_provider.tracer(Langfuse::LANGFUSE_TRACER_NAME).start_span("langfuse-span").finish
+
+      expect(exported_span_names).to eq(["langfuse-span"])
+    end
+
+    it "drops unknown instrumentation scopes by default" do
+      tracer_provider.tracer("dalli").start_span("cache-span").finish
+
+      expect(exported_span_names).to be_empty
+    end
+
+    it "exports spans with gen_ai attributes by default" do
+      span = tracer_provider.tracer("custom").start_span("genai-span")
+      span.set_attribute("gen_ai.system", "openai")
       span.finish
+
+      expect(exported_span_names).to eq(["genai-span"])
+    end
+
+    it "exports spans from known LLM instrumentation scopes by default" do
+      tracer_provider.tracer("langsmith.client").start_span("known-scope-span").finish
+
+      expect(exported_span_names).to eq(["known-scope-span"])
+    end
+
+    it "uses a custom should_export_span filter" do
+      config.should_export_span = ->(span) { span.name.start_with?("keep") }
+      custom_processor = described_class.new(config: config, exporter: exporter)
+      custom_provider = OpenTelemetry::SDK::Trace::TracerProvider.new
+      custom_provider.add_span_processor(custom_processor)
+
+      custom_provider.tracer("custom").start_span("keep-me").finish
+      custom_provider.tracer("custom").start_span("drop-me").finish
+      custom_provider.force_flush(timeout: 1)
+
+      expect(exporter.finished_spans.map(&:name)).to eq(["keep-me"])
+    end
+
+    it "logs and drops spans when should_export_span raises" do
+      config.should_export_span = ->(_span) { raise "boom" }
+      custom_processor = described_class.new(config: config, exporter: exporter)
+      custom_provider = OpenTelemetry::SDK::Trace::TracerProvider.new
+      custom_provider.add_span_processor(custom_processor)
+
+      expect(logger).to receive(:error).with(/should_export_span raised/)
+
+      custom_provider.tracer("custom").start_span("drop-me").finish
+      custom_provider.force_flush(timeout: 1)
+
+      expect(exporter.finished_spans).to be_empty
     end
   end
 

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -6,9 +6,11 @@ require "opentelemetry/sdk"
 RSpec.describe Langfuse do
   before do
     described_class.reset!
-    # Setup minimal OTel for testing
-    tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider.new
-    OpenTelemetry.tracer_provider = tracer_provider
+    described_class.configure do |config|
+      config.public_key = "pk_test"
+      config.secret_key = "sk_test"
+      config.base_url = "https://cloud.langfuse.com"
+    end
   end
 
   it "has a version number" do
@@ -43,6 +45,15 @@ RSpec.describe Langfuse do
       expect(described_class.configuration.secret_key).to eq("test_sk")
       expect(described_class.configuration.cache_ttl).to eq(300)
     end
+
+    it "does not eagerly initialize tracing" do
+      described_class.configure do |config|
+        config.public_key = "test_pk"
+        config.secret_key = "test_sk"
+      end
+
+      expect(Langfuse::OtelSetup.initialized?).to be false
+    end
   end
 
   describe ".client" do
@@ -74,6 +85,35 @@ RSpec.describe Langfuse do
       expect(client.api_client.public_key).to eq("pk_test_123")
       expect(client.api_client.secret_key).to eq("sk_test_456")
       expect(client.api_client.base_url).to eq("https://cloud.langfuse.com")
+    end
+  end
+
+  describe ".tracer_provider" do
+    it "raises when tracing is not ready" do
+      described_class.reset!
+      described_class.configure do |config|
+        config.public_key = nil
+        config.secret_key = nil
+        config.base_url = nil
+      end
+
+      expect { described_class.tracer_provider }.to raise_error(
+        Langfuse::ConfigurationError,
+        /Langfuse tracing is disabled/
+      )
+    end
+
+    it "lazily initializes and returns the internal tracer provider" do
+      described_class.configure do |config|
+        config.public_key = "pk_test"
+        config.secret_key = "sk_test"
+        config.base_url = "https://cloud.langfuse.com"
+      end
+
+      provider = described_class.tracer_provider
+
+      expect(provider).to be_a(OpenTelemetry::SDK::Trace::TracerProvider)
+      expect(Langfuse::OtelSetup.tracer_provider).to equal(provider)
     end
   end
 
@@ -406,6 +446,25 @@ RSpec.describe Langfuse do
   end
 
   describe ".observe" do
+    it "warns once and uses a no-op tracer when tracing is not ready" do
+      described_class.reset!
+      logger = instance_double(Logger, warn: nil)
+      described_class.configure do |config|
+        config.public_key = nil
+        config.secret_key = nil
+        config.base_url = nil
+        config.logger = logger
+      end
+
+      expect(logger).to receive(:warn).once.with(/Langfuse tracing is disabled/)
+
+      first = described_class.observe("first")
+      second = described_class.observe("second")
+
+      expect(first.otel_span.recording?).to be(false)
+      expect(second.otel_span.recording?).to be(false)
+    end
+
     it "creates and returns observation without block" do
       observation = described_class.observe("test", input: { data: "test" })
       expect(observation).to be_a(Langfuse::Span)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ SimpleCov.start do
 end
 
 require "langfuse"
+require "opentelemetry/sdk"
 require "webmock/rspec"
 require "logger"
 require "fileutils"
@@ -31,10 +32,17 @@ RSpec.configure do |config|
     FileUtils.mkdir_p("log")
     config.add_setting :test_logger
     config.test_logger = Logger.new("log/test.log")
+    OpenTelemetry.tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider.new
   end
 
   # Reset global Langfuse state before each test
   config.before do
+    ENV.delete("LANGFUSE_PUBLIC_KEY")
+    ENV.delete("LANGFUSE_SECRET_KEY")
+    ENV.delete("LANGFUSE_BASE_URL")
+    ENV.delete("LANGFUSE_TRACING_ENVIRONMENT")
+    ENV.delete("LANGFUSE_RELEASE")
+
     # Stub OTLP endpoint BEFORE reset (which may flush traces)
     # (tests can override this with more specific stubs if needed)
     stub_request(:post, %r{/api/public/otel/v1/traces})
@@ -44,8 +52,14 @@ RSpec.configure do |config|
 
     # Configure logger to write to log file instead of stdout
     Langfuse.configure do |c|
+      c.public_key = "pk_test"
+      c.secret_key = "sk_test"
+      c.base_url = "https://cloud.langfuse.com"
       c.logger = RSpec.configuration.test_logger
     end
+
+    OpenTelemetry.tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider.new
+    OpenTelemetry.propagation = OpenTelemetry::Context::Propagation::NoopTextMapPropagator.new
 
     # Stub Logger.new to use test log file when using $stdout, but allow other outputs
     test_logger = RSpec.configuration.test_logger

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 require "simplecov"
+require "simplecov_json_formatter"
 SimpleCov.start do
   add_filter "/spec/"
   # Maintain high coverage standards
   minimum_coverage 95
+  # CI uploads JSON coverage to Codecov while local runs still need HTML output.
+  formatter SimpleCov::Formatter::MultiFormatter.new(
+    [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::JSONFormatter]
+  )
 end
 
 require "langfuse"


### PR DESCRIPTION
#### `TL;DR`
Stop Langfuse from hijacking the global OpenTelemetry tracer provider by default, add lazy internal tracing setup plus smart export filtering, and document the explicit global-install escape hatch.

#### `Why`
GitHub issue #71 showed that `Langfuse.configure` was silently routing unrelated OpenTelemetry spans into Langfuse. That is the wrong default: it creates surprise ingestion, surprise spend, and makes Langfuse look like a global OTel sink instead of an LLM tracing SDK.

#### `Checklist`
- [x] Has label
- [x] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)

Closes #71

### Summary
- remove eager global OTel installation from `Langfuse.configure` and make module-level tracing lazily initialize an internal provider only when tracing is fully configured
- add `Langfuse.tracer_provider`, `should_export_span`, and public span-filter helpers so callers can explicitly opt into global install or compose custom export rules
- replace the separate exporter/filter path with a Langfuse-owned batch processor that enriches spans on start and gates export on finish
- add coverage for lazy setup, no-op warning behavior, idempotent setup, custom filtering, explicit global install, and default isolation from ambient global spans
- update README, configuration docs, API reference, and changelog for the breaking tracing behavior change

### Verification
- `bundle exec rspec`
- `bundle exec rubocop`
- isolated module trace ingested: `aai34-20260419225452-a36418ce-isolated-module`
- ambient global trace dropped: `aai34-20260419225452-a36418ce-ambient-dropped`
- explicit global install trace ingested: `aai34-20260419225452-a36418ce-global-opt-in`
- custom filter kept `aai34-20260419225452-a36418ce-custom-keep` and dropped `aai34-20260419225452-a36418ce-custom-drop`
