### PR TITLE
docs: align docs with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,50 @@
-![header](https://camo.githubusercontent.com/26d19b945bc752101b4aca468e07b118a44af07340db79af29f7df95505f2cea/68747470733a2f2f6c616e67667573652e636f6d2f6c616e67667573655f6c6f676f5f77686974652e706e67)
-
 # Langfuse Ruby SDK
 
-[![Gem Version](https://badge.fury.io/rb/langfuse-rb.svg?icon=si%3Arubygems)](https://badge.fury.io/rb/langfuse-rb)
-[![Ruby](https://img.shields.io/badge/ruby-%3E%3D%203.2.0-ruby.svg)](https://www.ruby-lang.org/en/)
-[![Test Coverage](https://img.shields.io/badge/coverage-99.6%25-brightgreen.svg)](coverage)
+Ruby SDK for [Langfuse](https://langfuse.com) prompt management, tracing, and scoring.
 
-> Ruby SDK for [Langfuse](https://langfuse.com) - Open-source LLM observability and prompt management.
-
-<br>
-
-### Features
-
-- 🎯 **Prompt Management** - Centralized prompt versioning with Mustache templating
-- 📊 **LLM Tracing** - Zero-boilerplate observability built on OpenTelemetry
-- ⚡ **Performance** - In-memory or Redis-backed caching with stampede protection, both supporting stale-while-revalidate cache strategy
-- 💬 **Chat & Text Prompts** - First-class support for both formats
-- 🔄 **Automatic Retries** - Built-in exponential backoff for resilient API calls
-- 🛡️ **Fallback Support** - Graceful degradation when API unavailable
-- 🚀 **Rails-Friendly** - Global configuration pattern, works with any Ruby project
-
-<br>
-
-### Installation
+## Installation
 
 ```ruby
-# Add to Gemfile & bundle install
-gem 'langfuse-rb'
+gem "langfuse-rb"
 ```
 
-<br>
-
-### Quick Start
-
-> Configure once at startup
+## Quick Start
 
 ```ruby
-# config/initializers/langfuse.rb (Rails)
-# Or at the top of your script
 Langfuse.configure do |config|
-  config.public_key = ENV['LANGFUSE_PUBLIC_KEY']
-  config.secret_key = ENV['LANGFUSE_SECRET_KEY']
-  # Optional: for self-hosted instances
-  config.base_url = ENV.fetch('LANGFUSE_BASE_URL', 'https://cloud.langfuse.com')
+  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
+  config.base_url = ENV.fetch("LANGFUSE_BASE_URL", "https://cloud.langfuse.com")
 
   # Optional: sample traces and trace-linked scores deterministically
   config.sample_rate = 1.0
-
-  # Optional: Enable stale-while-revalidate for best performance
-  config.cache_backend = :rails  # or :memory
-  config.cache_stale_while_revalidate = true
 end
+
+message = Langfuse.client.compile_prompt(
+  "greeting",
+  variables: { name: "Alice" }
+)
 ```
 
-> Langfuse tracing is isolated by default. `Langfuse.configure` stores configuration only; it does not replace `OpenTelemetry.tracer_provider`.
+Langfuse tracing is isolated by default. `Langfuse.configure` stores configuration only; it does not replace `OpenTelemetry.tracer_provider`.
 
-> `sample_rate` is applied to traces and trace-linked scores. Rebuild the client with `Langfuse.reset!` before expecting runtime sampling changes to take effect.
+`sample_rate` is applied to traces and trace-linked scores. Rebuild the client with `Langfuse.reset!` before expecting runtime sampling changes to take effect.
 
-> Fetch and use a prompt
-
-```ruby
-prompt = Langfuse.client.get_prompt("greeting")
-message = prompt.compile(name: "Alice")
-# => "Hello Alice!"
-```
-
-> Trace an LLM call
+## Trace an LLM Call
 
 ```ruby
 Langfuse.observe("chat-completion", as_type: :generation) do |gen|
+  gen.model = "gpt-4.1-mini"
+  gen.input = [{ role: "user", content: "Hello!" }]
+
   response = openai_client.chat(
     parameters: {
-      model: "gpt-4",
+      model: "gpt-4.1-mini",
       messages: [{ role: "user", content: "Hello!" }]
     }
   )
 
   gen.update(
-    model: "gpt-4",
     output: response.dig("choices", 0, "message", "content"),
     usage_details: {
       prompt_tokens: response.dig("usage", "prompt_tokens"),
@@ -87,67 +54,14 @@ Langfuse.observe("chat-completion", as_type: :generation) do |gen|
 end
 ```
 
-> Explicit OpenTelemetry global install (optional)
+## Start Here
 
-```ruby
-Langfuse.configure do |config|
-  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
-  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
-end
-
-OpenTelemetry.tracer_provider = Langfuse.tracer_provider
-```
-
-If you install Langfuse globally, you own that lifecycle. `Langfuse.shutdown` and `Langfuse.reset!` stop the internal provider, so reconfigure and reinstall it after resets.
-
-> Filter exported spans (optional)
-
-```ruby
-Langfuse.configure do |config|
-  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
-  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
-  config.should_export_span = lambda { |span|
-    Langfuse.default_export_span?(span) &&
-      span.instrumentation_scope&.name != "my_framework.worker"
-  }
-end
-```
-
-`should_export_span` runs synchronously on every ended span in the application thread. Keep it allocation-light, non-blocking, and free of network/database calls.
-
-> [!IMPORTANT]
-> For complete reference see [docs](./docs/) section.
-
-<br>
-
-### Requirements
-
-- Ruby >= 3.2.0
-- No Rails dependency (works with any Ruby project)
-
-<br>
-
-### Contributing
-
-We welcome contributions! Please:
-
-1. Check existing [issues](https://github.com/simplepractice/langfuse-rb/issues)
-2. Open an issue to discuss your idea
-3. Fork the repo and create a feature branch
-4. Write tests (maintain >95% coverage)
-5. Ensure `bundle exec rspec` and `bundle exec rubocop` pass
-6. Submit a pull request
-
-> [!TIP]
-> See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
-
-<br>
-
-### Support
-
-- **[GitHub Issues](https://github.com/simplepractice/langfuse-rb/issues)** - Bug reports and feature requests
-- **[Langfuse Documentation](https://langfuse.com/docs)** - Platform documentation
-- **[API Reference](https://api.reference.langfuse.com)** - REST API reference
+- [Documentation Hub](docs/README.md)
+- [Getting Started](docs/GETTING_STARTED.md)
+- [Prompts](docs/PROMPTS.md)
+- [Tracing](docs/TRACING.md)
+- [Scoring](docs/SCORING.md)
+- [Rails Patterns](docs/RAILS.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
+![header](https://camo.githubusercontent.com/26d19b945bc752101b4aca468e07b118a44af07340db79af29f7df95505f2cea/68747470733a2f2f6c616e67667573652e636f6d2f6c616e67667573655f6c6f676f5f77686974652e706e67)
+
 # Langfuse Ruby SDK
 
-Ruby SDK for [Langfuse](https://langfuse.com) prompt management, tracing, and scoring.
+[![Gem Version](https://badge.fury.io/rb/langfuse-rb.svg?icon=si%3Arubygems)](https://badge.fury.io/rb/langfuse-rb)
+[![Ruby](https://img.shields.io/badge/ruby-%3E%3D%203.2.0-ruby.svg)](https://www.ruby-lang.org/en/)
+[![Test Coverage](https://img.shields.io/badge/coverage-99.6%25-brightgreen.svg)](coverage)
+
+> Ruby SDK for [Langfuse](https://langfuse.com) - Open-source LLM observability and prompt management.
 
 ## Installation
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -53,8 +53,8 @@ Block receives a configuration object with these properties:
 | `logger`                       | Logger  | No       | Auto-detected                  | Logger instance                   |
 | `tracing_async`                | Boolean | No       | `true`                         | ⚠️ Experimental (OTel export mode) |
 | `job_queue`                    | Symbol  | No       | `:default`                     | ⚠️ Experimental (not implemented) |
-| `environment`                  | String  | No       | `nil`                          | Default trace environment          |
-| `release`                      | String  | No       | `nil`                          | Default release identifier         |
+| `environment`                  | String  | No       | `nil` (or `ENV["LANGFUSE_TRACING_ENVIRONMENT"]`) | Default trace environment          |
+| `release`                      | String  | No       | `nil` (or `ENV["LANGFUSE_RELEASE"]` / common CI commit SHA env) | Default release identifier         |
 | `should_export_span`           | `#call` | No       | `nil`                          | Span export filter callback        |
 | `mask`                         | `#call` | No       | `nil`                          | Mask callable for input/output/metadata (receives `data:` keyword) |
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -32,7 +32,7 @@ Langfuse.configure { |config| ... }
 
 **Parameters:**
 
-Block receives a configuration object with these properties:
+Block receives a `Langfuse::Config` object with these properties:
 
 | Property                       | Type    | Required | Default                        | Description                       |
 | ------------------------------ | ------- | -------- | ------------------------------ | --------------------------------- |
@@ -122,6 +122,8 @@ Langfuse.tracer_provider # => OpenTelemetry::SDK::Trace::TracerProvider
 
 **Raises:** `ConfigurationError` if `public_key`, `secret_key`, or `base_url` are not configured
 
+`Langfuse.configure` does not call this for you. This is the explicit global-install seam. If you also want another OpenTelemetry backend or custom propagation, that remains application-owned setup.
+
 **Example:**
 
 ```ruby
@@ -135,7 +137,7 @@ OpenTelemetry.tracer_provider = Langfuse.tracer_provider
 
 ### Span Filter Helpers
 
-These public helpers are useful when composing `should_export_span` callbacks.
+These public helpers are useful when composing `should_export_span` callbacks. The callback receives ended spans handled by Langfuse's provider.
 
 #### `Langfuse.default_export_span?`
 
@@ -144,7 +146,7 @@ Return whether a span matches Langfuse's default export allowlist.
 **Signature:**
 
 ```ruby
-Langfuse.default_export_span?(span) # => true | false
+Langfuse.default_export_span?(span) # => Boolean
 ```
 
 **Returns:** `true` for Langfuse spans, spans with `gen_ai.*` attributes, and spans from known LLM-related instrumentation scopes
@@ -156,7 +158,7 @@ Return whether a span was created by Langfuse's tracer.
 **Signature:**
 
 ```ruby
-Langfuse.langfuse_span?(span) # => true | false
+Langfuse.langfuse_span?(span) # => Boolean
 ```
 
 #### `Langfuse.genai_span?`
@@ -166,7 +168,7 @@ Return whether a span contains `gen_ai.*` attributes.
 **Signature:**
 
 ```ruby
-Langfuse.genai_span?(span) # => true | false
+Langfuse.genai_span?(span) # => Boolean
 ```
 
 #### `Langfuse.known_llm_instrumentor?`
@@ -176,7 +178,7 @@ Return whether a span came from one of Langfuse's known LLM-related instrumentat
 **Signature:**
 
 ```ruby
-Langfuse.known_llm_instrumentor?(span) # => true | false
+Langfuse.known_llm_instrumentor?(span) # => Boolean
 ```
 
 **Compatibility aliases:** `Langfuse.is_default_export_span`, `Langfuse.is_langfuse_span`, `Langfuse.is_genai_span`, `Langfuse.is_known_llm_instrumentor`
@@ -190,10 +192,10 @@ Get the global singleton client instance.
 **Signature:**
 
 ```ruby
-Langfuse.client # => Client
+Langfuse.client # => Langfuse::Client
 ```
 
-**Returns:** Client instance
+**Returns:** `Langfuse::Client`
 
 **Raises:** `ConfigurationError` if not configured
 
@@ -226,7 +228,7 @@ get_prompt(name, version: nil, label: nil, fallback: nil, type: nil)
 | `fallback` | String or Array<Hash> | No | Fallback prompt if not found (`String` for text, `Array<Hash>` for chat) |
 | `type`     | Symbol  | Conditional | `:text` or `:chat` (required if `fallback` provided) |
 
-**Returns:** `TextPromptClient` or `ChatPromptClient`
+**Returns:** `Langfuse::TextPromptClient` or `Langfuse::ChatPromptClient`
 
 **Raises:**
 
@@ -314,7 +316,7 @@ create_prompt(name:, prompt:, type:, config: {}, labels: [], tags: [], commit_me
 | `tags`           | Array<String>      | No       | Tags for categorization                                                  |
 | `commit_message` | String             | No       | Optional commit message                                                  |
 
-**Returns:** `TextPromptClient` or `ChatPromptClient`
+**Returns:** `Langfuse::TextPromptClient` or `Langfuse::ChatPromptClient`
 
 **Raises:**
 
@@ -356,7 +358,7 @@ update_prompt(name:, version:, labels:)
 | `version` | Integer       | Yes      | Prompt version to update                  |
 | `labels`  | Array<String> | Yes      | Replacement labels for that prompt version |
 
-**Returns:** `TextPromptClient` or `ChatPromptClient`
+**Returns:** `Langfuse::TextPromptClient` or `Langfuse::ChatPromptClient`
 
 **Raises:**
 
@@ -430,7 +432,7 @@ Returned by `get_prompt` for text prompts.
 | `version` | Integer       | Version number         |
 | `labels`  | Array<String> | Version labels         |
 | `tags`    | Array<String> | Tags                   |
-| `config`  | Hash          | Configuration metadata |
+| `config`  | Hash          | Prompt config hash returned by Langfuse |
 | `prompt`  | String        | Raw template           |
 
 **Methods:**
@@ -530,7 +532,7 @@ Create a traced observation (block or stateful mode).
 observe(name, attributes = {}, as_type: :span, trace_id: nil) { |obs| ... }
 
 # Stateful mode (manual end)
-observe(name, attributes = {}, as_type: :span, trace_id: nil) # => BaseObservation
+observe(name, attributes = {}, as_type: :span, trace_id: nil) # => Langfuse::BaseObservation
 ```
 
 **Parameters:**
@@ -570,6 +572,8 @@ obs.end
 
 See [TRACING.md](TRACING.md) for complete guide.
 
+For payload-bearing standalone events, pass event attributes at creation time. `:event` observations auto-end immediately, so mutating payload inside a later block is too late.
+
 ### `Langfuse.start_observation`
 
 Low-level factory for creating observations. Prefer `Langfuse.observe` for most use cases.
@@ -592,7 +596,7 @@ start_observation(name, attrs = {}, as_type: :span, trace_id: nil,
 | `parent_span_context`  | SpanContext  | No       | `nil`   | Parent span context for child observations                                  |
 | `start_time`           | Time/Integer | No       | `nil`   | Custom start time                                                           |
 
-**Returns:** `BaseObservation` (Span, Generation, Event, etc.)
+**Returns:** `Langfuse::BaseObservation` (or a subclass such as `Langfuse::Span`, `Langfuse::Generation`, or `Langfuse::Event`)
 
 **Raises:** `ArgumentError` if both `trace_id` and `parent_span_context` provided, or if `trace_id` is invalid
 
@@ -615,7 +619,7 @@ Returned by `observe` in stateful mode or passed to block.
 | ----------- | ------------------------------- | ---------------------------- |
 | `id`        | String                          | Observation ID (hex span ID) |
 | `trace_id`  | String                          | Trace ID (hex trace ID)      |
-| `trace_url` | String                          | URL to Langfuse UI           |
+| `trace_url` | `String` or `nil`              | URL to Langfuse UI, if project lookup succeeds |
 | `otel_span` | OpenTelemetry::SDK::Trace::Span | Underlying OTel span         |
 | `type`      | String                          | Observation type             |
 
@@ -662,7 +666,7 @@ obs.update_trace(
 #### `end`
 
 ```ruby
-end(end_time: Time.now) # => self
+end(end_time: Time.now)
 ```
 
 End the observation (block mode calls this automatically).
@@ -674,7 +678,7 @@ End the observation (block mode calls this automatically).
 start_observation(name, attributes = {}, as_type: :span) { |child| ... }
 
 # Stateful mode
-start_observation(name, attributes = {}, as_type: :span) # => BaseObservation
+start_observation(name, attributes = {}, as_type: :span) # => Langfuse::BaseObservation
 ```
 
 Create a child observation.
@@ -692,10 +696,10 @@ end
 #### `event`
 
 ```ruby
-event(name:, input: nil, output: nil, metadata: nil, level: "default") # => self
+event(name:, input: nil, level: "default")
 ```
 
-Add a point-in-time event to the observation.
+Add a point-in-time event to the observation's span.
 
 **Example:**
 
@@ -703,7 +707,6 @@ Add a point-in-time event to the observation.
 obs.event(
   name: "checkpoint",
   input: { step: 2 },
-  metadata: { timestamp: Time.now.iso8601 },
   level: "DEFAULT"
 )
 ```

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -80,10 +80,10 @@ Access current configuration.
 **Signature:**
 
 ```ruby
-Langfuse.configuration # => Configuration
+Langfuse.configuration # => Langfuse::Config
 ```
 
-**Returns:** Configuration object with all settings
+**Returns:** `Langfuse::Config` object with all settings
 
 **Example:**
 
@@ -132,6 +132,54 @@ end
 
 OpenTelemetry.tracer_provider = Langfuse.tracer_provider
 ```
+
+### Span Filter Helpers
+
+These public helpers are useful when composing `should_export_span` callbacks.
+
+#### `Langfuse.default_export_span?`
+
+Return whether a span matches Langfuse's default export allowlist.
+
+**Signature:**
+
+```ruby
+Langfuse.default_export_span?(span) # => true | false
+```
+
+**Returns:** `true` for Langfuse spans, spans with `gen_ai.*` attributes, and spans from known LLM-related instrumentation scopes
+
+#### `Langfuse.langfuse_span?`
+
+Return whether a span was created by Langfuse's tracer.
+
+**Signature:**
+
+```ruby
+Langfuse.langfuse_span?(span) # => true | false
+```
+
+#### `Langfuse.genai_span?`
+
+Return whether a span contains `gen_ai.*` attributes.
+
+**Signature:**
+
+```ruby
+Langfuse.genai_span?(span) # => true | false
+```
+
+#### `Langfuse.known_llm_instrumentor?`
+
+Return whether a span came from one of Langfuse's known LLM-related instrumentation scopes.
+
+**Signature:**
+
+```ruby
+Langfuse.known_llm_instrumentor?(span) # => true | false
+```
+
+**Compatibility aliases:** `Langfuse.is_default_export_span`, `Langfuse.is_langfuse_span`, `Langfuse.is_genai_span`, `Langfuse.is_known_llm_instrumentor`
 
 ## Client Access
 

--- a/docs/CACHING.md
+++ b/docs/CACHING.md
@@ -607,7 +607,7 @@ prompt = Langfuse.client.get_prompt(
 
 ```ruby
 # Rails console
-Langfuse.client.instance_variable_get(:@api_client).cache&.clear
+Langfuse.client.api_client.cache&.clear
 
 # Or use rake task
 rake langfuse:clear_cache

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,39 @@ end
 
 Call this once at application startup (Rails initializer, boot script, etc.).
 
-`Langfuse.configure` only stores configuration. Module-level tracing initializes lazily on first use, and Langfuse does not install itself into the global OpenTelemetry tracer provider unless you opt in with `Langfuse.tracer_provider`.
+## Tracing Ownership
+
+This is the part people get wrong.
+
+- `Langfuse.configure` stores configuration only.
+- Module-level tracing initializes lazily on first use.
+- Langfuse tracing is isolated by default.
+- `Langfuse.tracer_provider` is the explicit seam for installing Langfuse as the global OpenTelemetry provider.
+- `should_export_span` only runs on spans handled by Langfuse's provider.
+- Filtering is not the fix for ambient-span overcapture. Isolation is.
+- Langfuse does not auto-configure a second OpenTelemetry backend or any multi-export pipeline for you.
+
+Default isolated setup:
+
+```ruby
+Langfuse.configure do |config|
+  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
+end
+```
+
+Explicit global install:
+
+```ruby
+Langfuse.configure do |config|
+  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
+end
+
+OpenTelemetry.tracer_provider = Langfuse.tracer_provider
+```
+
+If you also want propagation or another OpenTelemetry backend, configure those in your application. Langfuse does not infer or install them.
 
 ## All Configuration Options
 
@@ -321,6 +353,8 @@ When Langfuse processes a span and no custom filter is configured, default behav
 
 Composing with `Langfuse.default_export_span?` keeps that allowlist and lets you add tighter exclusions.
 
+Use this callback to narrow a provider path Langfuse already owns. Do not treat it as the fix for default ambient-span overcapture. The isolated default already prevents that problem.
+
 #### `mask`
 
 - **Type:** `#call` (Proc, Lambda, or any object responding to `call`) or `nil`
@@ -342,12 +376,16 @@ See [TRACING.md](TRACING.md#masking) for usage patterns and behavior details.
 
 ## Tracing Behavior and OpenTelemetry Ownership
 
-Tracing is isolated by default:
+There are three states worth documenting.
+
+### Default Isolated Langfuse Tracing
 
 - `Langfuse.configure` does not mutate `OpenTelemetry.tracer_provider`
 - `Langfuse.configure` does not mutate `OpenTelemetry.propagation`
 - `Langfuse.observe(...)` uses Langfuse's internal tracer provider once tracing is ready
-- If `public_key`, `secret_key`, or `base_url` are missing, module-level tracing falls back to a no-op tracer and logs one warning
+- if `public_key`, `secret_key`, or `base_url` are missing, module-level tracing falls back to a no-op tracer and logs one warning
+
+### Explicit Global Install with `Langfuse.tracer_provider`
 
 If you want Langfuse to own the global OpenTelemetry provider, install it explicitly:
 
@@ -364,6 +402,13 @@ OpenTelemetry.propagation = OpenTelemetry::Trace::Propagation::TraceContext::Tex
 ```
 
 That global install is a lifecycle commitment. `Langfuse.shutdown` and `Langfuse.reset!` stop the internal provider. If you reset or reconfigure Langfuse, reinstall the tracer provider and any propagators you want afterward.
+
+### Additional OTel Backends Are Application-Owned
+
+If you want spans in another OpenTelemetry backend as well, configure that pipeline in your application. Langfuse does not auto-install multi-export. That can mean:
+
+- adding processors/exporters to the provider you own
+- or managing your own provider pipeline explicitly
 
 After the first successful tracing initialization, these settings require `Langfuse.reset!` before changes take effect:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -296,7 +296,7 @@ config.release = "2024.1"
 
 - **Type:** `#call` (Proc, Lambda, Method, or any object responding to `call`) or `nil`
 - **Default:** `nil` (uses Langfuse's default export filter)
-- **Description:** Controls whether an ended span is exported to Langfuse
+- **Description:** Controls whether an ended span handled by Langfuse's tracer provider is exported to Langfuse
 
 ```ruby
 config.should_export_span = lambda { |span|
@@ -305,13 +305,21 @@ config.should_export_span = lambda { |span|
 }
 ```
 
-Default behavior exports:
+This callback only runs for spans processed by Langfuse's tracer provider. Under the default isolated setup, ambient spans created on some other global OpenTelemetry provider never reach this filter.
+
+If you want shared OpenTelemetry spans to be eligible for this filter, install Langfuse explicitly:
+
+```ruby
+OpenTelemetry.tracer_provider = Langfuse.tracer_provider
+```
+
+When Langfuse processes a span and no custom filter is configured, default behavior exports:
 
 - Langfuse SDK spans
 - Spans with `gen_ai.*` attributes
 - Spans from conservative LLM-related instrumentation scopes such as `langsmith.*`, `openinference.*`, and `opentelemetry.instrumentation.anthropic.*`
 
-The allowlist is intentionally conservative. It exists to include obvious LLM-related scopes, not every Ruby instrumentation namespace.
+Composing with `Langfuse.default_export_span?` keeps that allowlist and lets you add tighter exclusions.
 
 #### `mask`
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -432,9 +432,8 @@ puts config.inspect
 ### Check Cache State
 
 ```ruby
-# Not exposed publicly, but useful in console debugging:
-cache = Langfuse.client.instance_variable_get(:@prompt_client).instance_variable_get(:@cache)
-puts "Cache backend: #{cache.class}"
+cache = Langfuse.client.api_client.cache
+puts "Cache backend: #{cache&.class || 'disabled'}"
 ```
 
 ### Test Credentials

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,316 +1,203 @@
 # Getting Started with Langfuse Ruby SDK
 
-This guide walks you through installing and using the Langfuse Ruby SDK from scratch.
+This is the happy path for a new consumer. The goal is simple: configure the SDK once, fetch a real prompt, send a real trace, and know where to go next without guessing how tracing works.
 
-## Prerequisites
+## Before You Start
 
-- Ruby >= 3.2.0
-- A Langfuse account (sign up at [langfuse.com](https://langfuse.com))
-- Your Langfuse API keys (found in your project settings)
+- Ruby `>= 3.2.0`
+- A Langfuse project with API keys
+- At least one prompt created in the Langfuse UI
 
-## Installation
-
-Add the gem to your Gemfile:
+## 1. Install the Gem
 
 ```ruby
-gem 'langfuse-rb'
+gem "langfuse-rb"
 ```
 
-Then run:
+Then install dependencies:
 
 ```bash
 bundle install
 ```
 
-Or install directly:
+## 2. Configure Langfuse Once at Startup
 
-```bash
-gem install langfuse-rb
-```
-
-## Configuration
-
-The SDK uses a global configuration pattern. Set up once at application startup.
-
-### Plain Ruby
+Rails first, because that is the common consumer path.
 
 ```ruby
-require 'langfuse'
-
-Langfuse.configure do |config|
-  config.public_key = ENV['LANGFUSE_PUBLIC_KEY']
-  config.secret_key = ENV['LANGFUSE_SECRET_KEY']
-  config.base_url = "https://cloud.langfuse.com"  # Optional, this is default
-end
-```
-
-### Rails
-
-Create `config/initializers/langfuse.rb`:
-
-```ruby
+# config/initializers/langfuse.rb
 Langfuse.configure do |config|
   config.public_key = Rails.application.credentials.dig(:langfuse, :public_key)
   config.secret_key = Rails.application.credentials.dig(:langfuse, :secret_key)
+  config.base_url = ENV.fetch("LANGFUSE_BASE_URL", "https://cloud.langfuse.com")
 
-  # Optional: Performance optimization
-  config.cache_backend = :rails  # Use Rails.cache (requires Redis)
-  config.cache_stale_while_revalidate = true  # Advisory intent flag
-  config.cache_stale_ttl = 60  # SWR activates when stale_ttl > 0
-  # Logger auto-detected as Rails.logger
+  config.cache_backend = :rails
+  config.cache_ttl = 300
+  config.cache_stale_ttl = 300
 end
 ```
 
-**Environment Variables:**
-
-Set these in your shell or `.env` file:
-
-```bash
-export LANGFUSE_PUBLIC_KEY="pk-lf-..."
-export LANGFUSE_SECRET_KEY="sk-lf-..."
-```
-
-**Tip:** If you're contributing to the SDK, use `make env` to quickly set up a `.env` file from the template.
-
-For all configuration options, see [CONFIGURATION.md](CONFIGURATION.md).
-
-## Your First Prompt
-
-Langfuse manages your LLM prompts centrally. Let's fetch and use one.
-
-### 1. Create a Prompt in Langfuse UI
-
-Go to your Langfuse dashboard → Prompts → Create new prompt:
-
-- **Name:** `greeting`
-- **Type:** Text
-- **Template:** `Hello {{name}}! Welcome to {{app_name}}.`
-
-### 2. Fetch and Compile
-
-**Plain Ruby:**
+Plain Ruby uses the same API:
 
 ```ruby
-require 'langfuse'
+require "langfuse"
 
-client = Langfuse.client
-prompt = client.get_prompt("greeting")
-
-# Compile with variables
-message = prompt.compile(name: "Alice", app_name: "MyApp")
-puts message
-# => "Hello Alice! Welcome to MyApp."
-```
-
-**Rails Controller:**
-
-```ruby
-class GreetingsController < ApplicationController
-  def show
-    client = Langfuse.client
-    prompt = client.get_prompt("greeting")
-
-    @message = prompt.compile(
-      name: current_user.name,
-      app_name: "MyApp"
-    )
-
-    render json: { message: @message }
-  end
+Langfuse.configure do |config|
+  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
+  config.base_url = ENV.fetch("LANGFUSE_BASE_URL", "https://cloud.langfuse.com")
 end
 ```
 
-### Convenience Method
+`Langfuse.configure` stores configuration only. It does not replace `OpenTelemetry.tracer_provider`. The default onboarding path is isolated tracing through the Langfuse helpers. If you want Langfuse to become the global OpenTelemetry provider, that is an explicit later step in [TRACING.md](TRACING.md#opentelemetry-integration).
 
-Fetch and compile in one call:
+For the full config surface, see [CONFIGURATION.md](CONFIGURATION.md).
+
+## 3. Fetch and Compile a Prompt
+
+Create a prompt in the Langfuse UI first. For example:
+
+- Name: `support-answer`
+- Type: chat
+- Label: `production`
+
+Then fetch and compile it in your app:
 
 ```ruby
-message = Langfuse.client.compile_prompt(
-  "greeting",
-  variables: { name: "Alice", app_name: "MyApp" }
+prompt = Langfuse.client.get_prompt("support-answer", label: "production")
+
+messages = prompt.compile(
+  customer_name: "Alice",
+  question: "How do I reset my password?"
 )
 ```
 
-See [PROMPTS.md](PROMPTS.md) for advanced prompt management (chat prompts, versioning, fallbacks).
-
-## Your First Trace
-
-Instrument any operation with `Langfuse.observe`:
-
-### Basic Tracing
-
-**Plain Ruby:**
+If you prefer the one-call version:
 
 ```ruby
-require 'langfuse'
-
-result = Langfuse.observe("generate-greeting", input: { name: "Alice" }) do |obs|
-  # Your code here
-  message = "Hello Alice!"
-
-  obs.update(output: { message: message })
-  message  # Return value
-end
-
-puts result  # => "Hello Alice!"
-```
-
-**Rails Service Object:**
-
-```ruby
-class GreetingService
-  def call(user)
-    Langfuse.observe("greeting-service", input: { user_id: user.id }) do |obs|
-      prompt = Langfuse.client.get_prompt("greeting")
-      message = prompt.compile(name: user.name, app_name: "MyApp")
-
-      obs.update(output: { message: message }, metadata: { user_id: user.id })
-      message
-    end
-  end
-end
-```
-
-### Tracing LLM Calls
-
-Use the `:generation` observation type for LLM calls:
-
-**Plain Ruby with OpenAI:**
-
-```ruby
-require 'openai'
-require 'langfuse'
-
-client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
-
-response = Langfuse.observe("openai-chat", { model: "gpt-4" }, as_type: :generation) do |gen|
-  result = client.chat(
-    parameters: {
-      model: "gpt-4",
-      messages: [{ role: "user", content: "Say hello!" }],
-      temperature: 0.7
-    }
-  )
-
-  gen.model = "gpt-4"
-  gen.model_parameters = { temperature: 0.7 }
-  gen.usage_details = {
-    prompt_tokens: result.dig("usage", "prompt_tokens"),
-    completion_tokens: result.dig("usage", "completion_tokens"),
-    total_tokens: result.dig("usage", "total_tokens")
+messages = Langfuse.client.compile_prompt(
+  "support-answer",
+  label: "production",
+  variables: {
+    customer_name: "Alice",
+    question: "How do I reset my password?"
   }
-  gen.output = result.dig("choices", 0, "message", "content")
-
-  result
-end
+)
 ```
 
-**Rails Background Job:**
+More prompt patterns live in [PROMPTS.md](PROMPTS.md).
+
+## 4. Send Your First Real Trace
+
+Use a root observation for the workflow, then nest the model call as a generation. This is the pattern most consumers actually want.
 
 ```ruby
-class AiSummaryJob < ApplicationJob
-  queue_as :default
+class SupportAnswerService
+  def initialize(llm_client:)
+    @llm_client = llm_client
+  end
 
-  def perform(article_id)
-    Langfuse.observe("summarize-article", { article_id: article_id }, as_type: :generation) do |gen|
-      article = Article.find(article_id)
+  def call(user:, question:)
+    Langfuse.propagate_attributes(
+      user_id: user.id.to_s,
+      session_id: "support-#{user.id}"
+    ) do
+      Langfuse.observe("support-answer", input: { question: question }) do |root|
+        prompt = Langfuse.client.get_prompt("support-answer", label: "production")
+        messages = prompt.compile(
+          customer_name: user.name,
+          question: question
+        )
 
-      response = openai_client.chat(
-        parameters: {
-          model: "gpt-4",
-          messages: [{ role: "user", content: "Summarize: #{article.body}" }]
-        }
-      )
+        answer = root.start_observation("llm-response", as_type: :generation) do |gen|
+          gen.model = "gpt-4.1-mini"
+          gen.input = messages
 
-      summary = response.dig("choices", 0, "message", "content")
+          response = @llm_client.chat(
+            parameters: {
+              model: "gpt-4.1-mini",
+              messages: messages
+            }
+          )
 
-      gen.model = "gpt-4"
-      gen.input = { article_body: article.body[0..100] }
-      gen.output = { summary: summary }
-      gen.usage_details = {
-        prompt_tokens: response.dig("usage", "prompt_tokens"),
-        completion_tokens: response.dig("usage", "completion_tokens"),
-        total_tokens: response.dig("usage", "total_tokens")
-      }
+          answer = response.dig("choices", 0, "message", "content")
 
-      article.update!(ai_summary: summary)
+          gen.update(
+            output: answer,
+            usage_details: {
+              prompt_tokens: response.dig("usage", "prompt_tokens"),
+              completion_tokens: response.dig("usage", "completion_tokens"),
+              total_tokens: response.dig("usage", "total_tokens")
+            }
+          )
+
+          answer
+        end
+
+        root.event(name: "reply-generated", input: { channel: "support" })
+        root.update(output: { answer: answer })
+
+        answer
+      end
     end
   end
 end
 ```
 
-See [TRACING.md](TRACING.md) for advanced patterns (nested spans, RAG, multi-turn conversations).
+Why this shape matters:
 
-## Verify It's Working
+- The root observation gives you a real trace entrypoint
+- The nested generation carries model-specific fields like `model` and `usage_details`
+- `root.event(...)` persists a point-in-time annotation on the active observation
+- `root.update(...)` persists the final workflow output instead of leaving the trace half-empty
 
-After running traced code, check your Langfuse dashboard:
-
-1. Go to **Traces** tab
-2. Find your trace by name (e.g., "generate-greeting")
-3. Click to see detailed timeline, inputs/outputs, and metadata
-
-You can also get the trace URL programmatically:
+Plain Ruby is the same pattern without Rails wrappers:
 
 ```ruby
-Langfuse.observe("my-operation") do |obs|
-  puts obs.trace_url
-  # => "https://cloud.langfuse.com/project/{project_id}/traces/abc123..."
+Langfuse.observe("support-answer", input: { question: question }) do |root|
+  answer = root.start_observation("llm-response", as_type: :generation) do |gen|
+    gen.model = "gpt-4.1-mini"
+    # ...
+  end
+
+  root.update(output: { answer: answer })
 end
 ```
 
-## Troubleshooting
+For deeper tracing patterns, see [TRACING.md](TRACING.md).
 
-### Authentication Errors
+## 5. Verify It Worked
+
+After running the code:
+
+1. Open the Langfuse UI.
+2. Find the `support-answer` trace.
+3. Confirm you can see:
+   - the root observation input and output
+   - the nested `llm-response` generation
+   - usage details on the generation
+   - the `reply-generated` event
+
+If you do not see traces, start with [ERROR_HANDLING.md](ERROR_HANDLING.md) and the Rails operational checks in [RAILS.md](RAILS.md#troubleshooting).
+
+## 6. Add Scores Once Traces Exist
+
+Do not invent a scoring workflow before the trace is working. First make the trace visible, then attach evaluation or feedback signals.
+
+Example:
 
 ```ruby
-# Error: Langfuse::UnauthorizedError
-# Solution: Check your API keys
-```
-
-Verify keys are correct:
-
-```ruby
-Langfuse.configure do |config|
-  puts "Public key: #{config.public_key}"  # Should start with "pk-lf-"
-  puts "Secret key: #{config.secret_key[0..8]}..."  # Should start with "sk-lf-"
+Langfuse.observe("support-answer") do |root|
+  # ... do work ...
+  root.score_trace(name: "customer-satisfaction", value: 5)
 end
 ```
 
-### Prompts Not Found
+Scoring details live in [SCORING.md](SCORING.md).
 
-```ruby
-# Error: Langfuse::NotFoundError: Prompt 'greeting' not found
-# Solution: Ensure prompt exists in Langfuse UI and is deployed
-```
+## What to Read Next
 
-Use fallback for development:
-
-```ruby
-prompt = client.get_prompt("greeting",
-  fallback: "Hello {{name}}!",
-  type: :text
-)
-```
-
-### Connection Timeouts
-
-```ruby
-# Increase timeout in config
-Langfuse.configure do |config|
-  config.timeout = 10  # Default is 5 seconds
-end
-```
-
-See [ERROR_HANDLING.md](ERROR_HANDLING.md) for complete error reference.
-
-## See Also
-
-- [Prompts Guide](PROMPTS.md) - Chat prompts, versioning, Mustache templating
-- [Tracing Guide](TRACING.md) - Nested observations, RAG patterns, OpenTelemetry
-- [Scoring Guide](SCORING.md) - Add quality scores to traces
-- [Datasets Guide](DATASETS.md) - Create and manage evaluation datasets
-- [Experiments Guide](EXPERIMENTS.md) - Run evaluations against datasets
-- [Caching Guide](CACHING.md) - In-memory and Rails.cache backends, SWR
-- [Configuration Reference](CONFIGURATION.md) - All configuration options
-- [Rails Integration](RAILS.md) - Rails-specific patterns and testing
-- [API Reference](API_REFERENCE.md) - Complete method reference
+- [PROMPTS.md](PROMPTS.md) if prompt versioning and fallbacks are your next problem
+- [TRACING.md](TRACING.md) if you need nested workflows, events, jobs, or OpenTelemetry integration
+- [SCORING.md](SCORING.md) if you want feedback or eval signals on traces
+- [RAILS.md](RAILS.md) if you are wiring this into controllers, services, or background jobs

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -35,7 +35,7 @@ The SDK uses a global configuration pattern. Set up once at application startup.
 ### Plain Ruby
 
 ```ruby
-require 'langfuse-rb'
+require 'langfuse'
 
 Langfuse.configure do |config|
   config.public_key = ENV['LANGFUSE_PUBLIC_KEY']
@@ -55,7 +55,8 @@ Langfuse.configure do |config|
 
   # Optional: Performance optimization
   config.cache_backend = :rails  # Use Rails.cache (requires Redis)
-  config.cache_stale_while_revalidate = true  # Serve stale data while refreshing (recommended for production)
+  config.cache_stale_while_revalidate = true  # Advisory intent flag
+  config.cache_stale_ttl = 60  # SWR activates when stale_ttl > 0
   # Logger auto-detected as Rails.logger
 end
 ```
@@ -90,7 +91,7 @@ Go to your Langfuse dashboard → Prompts → Create new prompt:
 **Plain Ruby:**
 
 ```ruby
-require 'langfuse-rb'
+require 'langfuse'
 
 client = Langfuse.client
 prompt = client.get_prompt("greeting")
@@ -141,7 +142,7 @@ Instrument any operation with `Langfuse.observe`:
 **Plain Ruby:**
 
 ```ruby
-require 'langfuse-rb'
+require 'langfuse'
 
 result = Langfuse.observe("generate-greeting", input: { name: "Alice" }) do |obs|
   # Your code here
@@ -178,7 +179,7 @@ Use the `:generation` observation type for LLM calls:
 
 ```ruby
 require 'openai'
-require 'langfuse-rb'
+require 'langfuse'
 
 client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
 
@@ -253,7 +254,7 @@ You can also get the trace URL programmatically:
 ```ruby
 Langfuse.observe("my-operation") do |obs|
   puts obs.trace_url
-  # => "https://cloud.langfuse.com/traces/abc123..."
+  # => "https://cloud.langfuse.com/project/{project_id}/traces/abc123..."
 end
 ```
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -686,7 +686,7 @@ prompts:
 # In Rails console
 Langfuse.reset!  # Clears everything
 # Or just clear cache
-Langfuse.client.instance_variable_get(:@api_client).cache&.clear
+Langfuse.client.api_client.cache&.clear
 ```
 
 ### Problem: Variables not substituting correctly

--- a/docs/RAILS.md
+++ b/docs/RAILS.md
@@ -503,8 +503,9 @@ class LangfuseMetrics
     status, headers, response = @app.call(env)
 
     # Log cache stats
-    if Langfuse.client.respond_to?(:cache_stats)
-      Rails.logger.info("Langfuse cache stats: #{Langfuse.client.cache_stats}")
+    stats = Langfuse::CacheWarmer.new.cache_stats
+    if stats
+      Rails.logger.info("Langfuse cache stats: #{stats}")
     end
 
     [status, headers, response]

--- a/docs/RAILS.md
+++ b/docs/RAILS.md
@@ -1,195 +1,133 @@
 # Rails Integration Guide
 
-Complete guide for integrating the Langfuse Ruby SDK into your Rails application.
+This guide assumes you already read [GETTING_STARTED.md](GETTING_STARTED.md). It is for applied Rails patterns, not basic setup repetition.
 
-For basic setup and configuration options, see [GETTING_STARTED.md](GETTING_STARTED.md) and [CONFIGURATION.md](CONFIGURATION.md).
+## Initializer Pattern
 
-## Table of Contents
-
-- [Configuration](#configuration)
-- [Usage Patterns](#usage-patterns)
-- [Background Jobs](#background-jobs)
-- [Testing](#testing)
-- [Deployment](#deployment)
-- [Best Practices](#best-practices)
-
-## Configuration
-
-See [GETTING_STARTED.md](GETTING_STARTED.md#rails) for Rails-specific setup and [CONFIGURATION.md](CONFIGURATION.md) for all options.
-
-**Quick reference:**
+Keep Langfuse setup in one initializer and keep the ownership boundary explicit.
 
 ```ruby
 # config/initializers/langfuse.rb
 Langfuse.configure do |config|
   config.public_key = Rails.application.credentials.dig(:langfuse, :public_key)
   config.secret_key = Rails.application.credentials.dig(:langfuse, :secret_key)
-  config.cache_backend = :rails  # Use Rails.cache (Redis)
+  config.base_url = ENV.fetch("LANGFUSE_BASE_URL", "https://cloud.langfuse.com")
+
+  config.cache_backend = :rails
   config.cache_ttl = Rails.env.production? ? 300 : 60
-  # Logger auto-detected as Rails.logger
+  config.cache_stale_ttl = Rails.env.production? ? 300 : 0
+  config.logger = Rails.logger
+end
+
+at_exit do
+  Langfuse.shutdown(timeout: 10)
 end
 ```
 
-## Usage Patterns
+Notes:
 
-### In Controllers
+- `Langfuse.configure` stores config only
+- module-level tracing works without replacing the global `OpenTelemetry.tracer_provider`
+- if you do choose a global install with `Langfuse.tracer_provider`, that is a separate explicit step and you own its lifecycle
+
+## Controller Pattern
+
+Controllers should usually create the root observation, set request-scoped trace attributes, and delegate actual LLM work to a service.
 
 ```ruby
-class UsersController < ApplicationController
+class SupportAnswersController < ApplicationController
   def create
-    # Fetch and compile prompt
-    prompt = Langfuse.client.get_prompt("welcome-email", label: "production")
-    email_body = prompt.compile(
-      user_name: params[:name],
-      app_url: root_url
-    )
-
-    # Send email
-    UserMailer.welcome_email(params[:email], email_body).deliver_later
-
-    render json: { message: "User created" }, status: :created
-  end
-end
-```
-
-### In Service Objects
-
-```ruby
-# app/services/ai_assistant_service.rb
-class AiAssistantService
-  def initialize(user)
-    @user = user
-    @client = Langfuse.client
-  end
-
-  def generate_response(question)
     Langfuse.propagate_attributes(
-      user_id: @user.id.to_s,
-      metadata: { question: question }
+      user_id: current_user.id.to_s,
+      session_id: request.request_id
     ) do
-      Langfuse.observe("ai-assistant", input: { question: question }) do |trace|
-        # Get prompt from Langfuse
-        prompt = @client.get_prompt("assistant-chat", label: Rails.env)
-
-        # Compile with user context
-        messages = prompt.compile(
-          user_name: @user.name,
-          user_context: @user.context_summary
+      Langfuse.observe("support-answer-request", input: { question: params[:question] }) do |root|
+        answer = SupportAnswerService.new.call(
+          user: current_user,
+          question: params[:question]
         )
 
-        # Call LLM with tracing
-        response = trace.start_observation("gpt4-response", as_type: :generation) do |gen|
-          gen.model = "gpt-4"
-          gen.model_parameters = { temperature: 0.7 }
-          gen.input = messages
+        root.event(name: "response-rendered", input: { format: "json" })
+        root.update(output: { answered: true })
 
-          result = call_openai(messages)
-          gen.output = result[:content]
-          gen.usage_details = result[:usage]
-          result[:content]
-        end
-
-        trace.update(output: { response: response })
-        response
+        render json: { answer: answer }
       end
     end
   end
-
-  private
-
-  def call_openai(messages)
-    # Your OpenAI implementation
-  end
 end
 ```
 
-### In Models
+The controller owns request context. The service owns prompt selection and model calls.
+
+## Service Object Pattern
+
+This is where most Rails consumers should put Langfuse prompt + generation logic.
 
 ```ruby
-class Document < ApplicationRecord
-  def summarize
-    prompt = Langfuse.client.get_prompt(
-      "document-summary",
-      fallback: "Summarize this document: {{content}}",
-      type: :text
-    )
+class SupportAnswerService
+  def initialize(llm_client: OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY")))
+    @llm_client = llm_client
+  end
 
-    prompt.compile(
-      content: self.content,
-      max_length: 500
-    )
+  def call(user:, question:)
+    Langfuse.observe("support-answer", input: { question: question }) do |root|
+      prompt = Langfuse.client.get_prompt("support-answer", label: Rails.env.production? ? "production" : "staging")
+      messages = prompt.compile(customer_name: user.name, question: question)
+
+      answer = root.start_observation("openai-chat", as_type: :generation) do |gen|
+        gen.model = "gpt-4.1-mini"
+        gen.input = messages
+        gen.model_parameters = { temperature: 0.2 }
+
+        response = @llm_client.chat(
+          parameters: {
+            model: "gpt-4.1-mini",
+            messages: messages,
+            temperature: 0.2
+          }
+        )
+
+        answer = response.dig("choices", 0, "message", "content")
+
+        gen.update(
+          output: answer,
+          usage_details: {
+            prompt_tokens: response.dig("usage", "prompt_tokens"),
+            completion_tokens: response.dig("usage", "completion_tokens"),
+            total_tokens: response.dig("usage", "total_tokens")
+          }
+        )
+
+        answer
+      end
+
+      root.update(output: { answer: answer })
+      answer
+    end
   end
 end
 ```
 
-### In Mailers
+This keeps the trace shape honest:
 
-```ruby
-class UserMailer < ApplicationMailer
-  def welcome_email(user)
-    prompt = Langfuse.client.get_prompt("welcome-email-template")
-
-    @body = prompt.compile(
-      user_name: user.name,
-      verification_url: user_verification_url(user)
-    )
-
-    mail(to: user.email, subject: "Welcome!")
-  end
-end
-```
+- controller/request span at the edge
+- workflow root in the service
+- generation for the model call itself
 
 ## Background Jobs
 
-### Sidekiq Integration
+Jobs are where people usually lie to themselves about propagation. Rails does not continue Langfuse trace context across processes for you.
 
-```ruby
-class ProcessDocumentJob < ApplicationJob
-  queue_as :default
-
-  def perform(document_id, trace_id = nil)
-    document = Document.find(document_id)
-
-    # Create new observation with metadata linking to original trace
-    Langfuse.propagate_attributes(
-      metadata: { document_id: document_id, queue: :default, original_trace_id: trace_id }
-    ) do
-      Langfuse.observe("process-document-job", input: { document_id: document_id }) do |trace|
-        text = trace.start_observation("extract-text") do |span|
-          text = extract_text(document)
-          span.update(output: { text_length: text.length })
-          text
-        end
-
-        trace.start_observation("summarize", as_type: :generation) do |gen|
-          gen.model = "gpt-4"
-          summary = generate_summary(text)
-          gen.update(output: summary)
-          document.update!(summary: summary)
-        end
-      end
-    end
-  end
-end
-```
-
-### Enqueue with Trace Context
+### Enqueue with Explicit Trace Context
 
 ```ruby
 class DocumentsController < ApplicationController
   def create
-    Langfuse.observe("document-upload", input: document_params) do |trace|
+    Langfuse.observe("document-upload", input: document_params.to_h) do |root|
       document = Document.create!(document_params)
 
-      # Get trace ID to pass to background job
-      trace_id = trace.trace_id
-      ProcessDocumentJob.perform_later(document.id, trace_id)
-
-      trace.start_observation(
-        "job-enqueued",
-        { input: { document_id: document.id } },
-        as_type: :event
-      )
+      ProcessDocumentJob.perform_later(document.id, root.trace_id)
+      root.event(name: "job-enqueued", input: { document_id: document.id, queue: "default" })
 
       render json: document, status: :created
     end
@@ -197,442 +135,157 @@ class DocumentsController < ApplicationController
 end
 ```
 
-### ActiveJob Configuration
+### Continue the Trace in the Job
 
-OpenTelemetry automatically handles async tracing. No additional configuration needed for ActiveJob integration.
+```ruby
+class ProcessDocumentJob < ApplicationJob
+  queue_as :default
+
+  def perform(document_id, trace_id)
+    document = Document.find(document_id)
+
+    Langfuse.observe("process-document", { input: { document_id: document_id } }, trace_id: trace_id) do |root|
+      text = root.start_observation("extract-text") do |span|
+        extracted_text = extract_text(document)
+        span.update(output: { characters: extracted_text.length })
+        extracted_text
+      end
+
+      summary = root.start_observation("summarize", as_type: :generation) do |gen|
+        gen.model = "gpt-4.1-mini"
+        result = summarize_with_llm(text)
+        gen.update(output: result.fetch(:summary), usage_details: result.fetch(:usage))
+        result.fetch(:summary)
+      end
+
+      root.update(output: { summary: summary })
+      document.update!(summary: summary)
+    end
+  end
+end
+```
+
+Passing `trace_id` is the pragmatic default. It rejoins the same trace, but it does not restore an exact parent span relationship across process boundaries. If you need that, carry and restore OpenTelemetry context yourself.
 
 ## Testing
 
-### RSpec Configuration
+Reset global state between examples and stub external calls aggressively.
 
 ```ruby
-# spec/rails_helper.rb or spec/spec_helper.rb
 RSpec.configure do |config|
-  config.before(:each) do
-    Langfuse.reset!  # Clear global state between tests
-  end
-
-  # Don't make real API calls in tests
-  config.before(:each, type: :request) do
-    allow_any_instance_of(Langfuse::Client).to receive(:get_prompt).and_call_original
+  config.before do
+    Langfuse.reset!
   end
 end
 ```
 
-### Mocking Prompts
+Stub prompt fetches at the client boundary:
 
 ```ruby
-# spec/support/langfuse_helpers.rb
-module LangfuseHelpers
-  def mock_langfuse_prompt(name, content, type: :text)
-    allow_any_instance_of(Langfuse::Client)
-      .to receive(:get_prompt)
-      .with(name, any_args)
-      .and_return(
-        if type == :text
-          Langfuse::TextPromptClient.new(
-            "name" => name,
-            "version" => 1,
-            "type" => "text",
-            "prompt" => content,
-            "labels" => ["test"],
-            "tags" => [],
-            "config" => {}
-          )
-        else
-          Langfuse::ChatPromptClient.new(
-            "name" => name,
-            "version" => 1,
-            "type" => "chat",
-            "prompt" => content,
-            "labels" => ["test"],
-            "tags" => [],
-            "config" => {}
-          )
-        end
-      )
-  end
-end
-
-RSpec.configure do |config|
-  config.include LangfuseHelpers
-end
-```
-
-### Example Test
-
-```ruby
-# spec/services/ai_assistant_service_spec.rb
-require 'rails_helper'
-
-RSpec.describe AiAssistantService do
-  let(:user) { create(:user, name: "Alice") }
-  let(:service) { described_class.new(user) }
-
-  before do
-    mock_langfuse_prompt(
-      "assistant-chat",
-      [
-        { "role" => "system", "content" => "You are an assistant for {{user_name}}" },
-        { "role" => "user", "content" => "{{question}}" }
-      ],
-      type: :chat
+RSpec.describe SupportAnswerService do
+  let(:prompt) do
+    instance_double(
+      Langfuse::ChatPromptClient,
+      compile: [{ role: "user", content: "How do I reset my password?" }]
     )
   end
 
-  it "generates a response using the prompt" do
-    allow(service).to receive(:call_openai).and_return({
-      content: "Hello Alice!",
-      usage: { prompt_tokens: 10, completion_tokens: 5 }
-    })
-
-    response = service.generate_response("What is Ruby?")
-
-    expect(response).to eq("Hello Alice!")
+  before do
+    allow(Langfuse.client).to receive(:get_prompt)
+      .with("support-answer", label: "staging")
+      .and_return(prompt)
   end
 end
 ```
 
-### Integration Tests
+For SDK integration coverage, prefer the repo's existing WebMock/VCR patterns instead of sprinkling real HTTP into ordinary Rails specs.
 
-For integration tests that actually call the Langfuse API, use VCR:
+## Production Hardening
 
-```ruby
-# Gemfile (test group)
-gem 'vcr'
-gem 'webmock'
-```
+### Cache Settings
 
-```ruby
-# spec/support/vcr.rb
-require 'vcr'
-
-VCR.configure do |config|
-  config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
-  config.hook_into :webmock
-  config.configure_rspec_metadata!
-
-  # Filter sensitive data
-  config.filter_sensitive_data('<LANGFUSE_PUBLIC_KEY>') { ENV['LANGFUSE_PUBLIC_KEY'] }
-  config.filter_sensitive_data('<LANGFUSE_SECRET_KEY>') { ENV['LANGFUSE_SECRET_KEY'] }
-end
-```
-
-```ruby
-# spec/integration/langfuse_api_spec.rb
-require 'rails_helper'
-
-RSpec.describe 'Langfuse API Integration', vcr: true do
-  it 'fetches a real prompt from Langfuse' do
-    prompt = Langfuse.client.get_prompt('greeting')
-
-    expect(prompt).to be_a(Langfuse::TextPromptClient)
-    expect(prompt.name).to eq('greeting')
-  end
-end
-```
-
-## Deployment
-
-### Heroku
-
-Add environment variables:
-
-```bash
-heroku config:set LANGFUSE_PUBLIC_KEY=pk-lf-...
-heroku config:set LANGFUSE_SECRET_KEY=sk-lf-...
-```
-
-### Docker
-
-In your `Dockerfile` or `docker-compose.yml`:
-
-```yaml
-# docker-compose.yml
-services:
-  web:
-    environment:
-      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
-      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
-```
-
-### Kubernetes
-
-Use Kubernetes secrets:
-
-```yaml
-# config/secrets.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: langfuse-secrets
-type: Opaque
-data:
-  public-key: <base64-encoded-key>
-  secret-key: <base64-encoded-key>
-```
-
-```yaml
-# deployment.yaml
-env:
-  - name: LANGFUSE_PUBLIC_KEY
-    valueFrom:
-      secretKeyRef:
-        name: langfuse-secrets
-        key: public-key
-  - name: LANGFUSE_SECRET_KEY
-    valueFrom:
-      secretKeyRef:
-        name: langfuse-secrets
-        key: secret-key
-```
-
-### Health Checks
-
-Add a health check endpoint that verifies Langfuse connectivity:
-
-```ruby
-# config/routes.rb
-get '/health/langfuse', to: 'health#langfuse'
-
-# app/controllers/health_controller.rb
-class HealthController < ApplicationController
-  def langfuse
-    # Try to fetch a test prompt
-    Langfuse.client.get_prompt('health-check', fallback: "OK", type: :text)
-
-    render json: { status: 'ok', service: 'langfuse' }
-  rescue => e
-    render json: { status: 'error', service: 'langfuse', error: e.message }, status: :service_unavailable
-  end
-end
-```
-
-### Graceful Shutdown
-
-Ensure traces are flushed on shutdown:
-
-```ruby
-# config/initializers/langfuse.rb (at the end)
-at_exit do
-  Langfuse.shutdown(timeout: 10)
-end
-```
-
-## Best Practices
-
-### 1. Use Environment-Specific Labels
-
-```ruby
-# Fetch prompts by environment
-prompt = Langfuse.client.get_prompt("greeting", label: Rails.env)
-
-# Or use conditional logic
-label = Rails.env.production? ? "production" : "development"
-prompt = Langfuse.client.get_prompt("greeting", label: label)
-```
-
-### 2. Always Provide Fallbacks in Production
-
-```ruby
-# config/initializers/langfuse.rb
-fallback_enabled = Rails.env.production?
-
-# In your code
-prompt = Langfuse.client.get_prompt(
-  "greeting",
-  fallback: fallback_enabled ? "Hello {{name}}!" : nil,
-  type: fallback_enabled ? :text : nil
-)
-```
-
-### 3. Cache Prompts Aggressively in Production
+For multi-process Rails deployments, `cache_backend = :rails` is usually the right default if `Rails.cache` is already backed by Redis.
 
 ```ruby
 Langfuse.configure do |config|
-  # Long cache in production, short in development
-  config.cache_ttl = Rails.env.production? ? 600 : 30  # 10 min vs 30 sec
+  config.cache_backend = :rails
+  config.cache_ttl = 300
+  config.cache_stale_ttl = 300
 end
 ```
 
-### 4. Use Service Objects for Complex LLM Logic
+### Prompt Fallbacks
 
-Instead of putting LLM logic in controllers:
+Use fallbacks for prompts that must not take the request path down:
 
 ```ruby
-# Good: Service object
-class ChatService
-  def initialize(user)
-    @user = user
-  end
-
-  def generate_response(message)
-    # Complex logic here
-  end
-end
-
-# In controller
-class ChatsController < ApplicationController
-  def create
-    service = ChatService.new(current_user)
-    response = service.generate_response(params[:message])
-    render json: { response: response }
-  end
-end
+prompt = Langfuse.client.get_prompt(
+  "support-answer",
+  label: "production",
+  fallback: [
+    { role: "system", content: "You are a helpful assistant." },
+    { role: "user", content: "{{question}}" }
+  ],
+  type: :chat
+)
 ```
 
-### 5. Log Prompt Fetches in Development
+### Global OTel Install
+
+If you install `Langfuse.tracer_provider` as the global provider, remember the lifecycle contract:
+
+- `Langfuse.reset!` tears down the internal provider
+- `Langfuse.shutdown` shuts it down
+- after either one, you must reinstall the provider yourself if the app still expects it globally
+
+## Operational Debugging
+
+Turn logging up when you need to see configuration and export behavior:
 
 ```ruby
-# config/environments/development.rb
-config.after_initialize do
-  Rails.logger.info "Langfuse configured with cache_ttl: #{Langfuse.configuration.cache_ttl}"
+Langfuse.configure do |config|
+  config.logger = Rails.logger
+  config.logger.level = Logger::DEBUG
 end
 ```
 
-### 6. Monitor Cache Hit Rates
-
-Add instrumentation to track cache effectiveness:
+Useful console checks:
 
 ```ruby
-# app/middleware/langfuse_metrics.rb
-class LangfuseMetrics
-  def initialize(app)
-    @app = app
-  end
-
-  def call(env)
-    status, headers, response = @app.call(env)
-
-    # Log cache stats
-    stats = Langfuse::CacheWarmer.new.cache_stats
-    if stats
-      Rails.logger.info("Langfuse cache stats: #{stats}")
-    end
-
-    [status, headers, response]
-  end
-end
-```
-
-### 7. Use Tracing for LLM Observability
-
-```ruby
-# Always wrap LLM calls in observations for observability
-def generate_content(prompt_text)
-  Langfuse.propagate_attributes(user_id: current_user.id.to_s) do
-    Langfuse.observe("generate-content", input: { prompt: prompt_text }) do |span|
-      span.start_observation("openai", as_type: :generation) do |gen|
-        gen.model = "gpt-4"
-        result = call_openai(prompt_text)
-        gen.update(output: result)
-        result
-      end
-    end
-  end
-end
-```
-
-### 8. Handle Rate Limits Gracefully
-
-```ruby
-def fetch_prompt_with_retry(name, max_retries: 3)
-  retries = 0
-
-  begin
-    Langfuse.client.get_prompt(name)
-  rescue Langfuse::ApiError => e
-    retries += 1
-    if retries < max_retries
-      sleep(2 ** retries)  # Exponential backoff
-      retry
-    else
-      # Use fallback
-      Rails.logger.error("Langfuse API failed after #{max_retries} retries: #{e.message}")
-      return fallback_prompt(name)
-    end
-  end
-end
-```
-
-### 9. Organize Prompts by Feature
-
-Use naming conventions:
-
-```
-# Good naming structure
-feature-action-context
-  - email-welcome-user
-  - email-reset-password
-  - chat-support-greeting
-  - chat-support-farewell
-  - summary-document-short
-  - summary-document-detailed
-```
-
-### 10. Test Prompt Compilation Separately
-
-```ruby
-# spec/prompts/greeting_prompt_spec.rb
-RSpec.describe 'Greeting Prompt' do
-  it 'compiles correctly with all variables' do
-    prompt = mock_langfuse_prompt('greeting', 'Hello {{name}}!')
-
-    result = prompt.compile(name: 'Alice')
-
-    expect(result).to eq('Hello Alice!')
-  end
-
-  it 'handles missing variables gracefully' do
-    prompt = mock_langfuse_prompt('greeting', 'Hello {{name}}!')
-
-    # Mustache renders empty string for missing variables
-    result = prompt.compile({})
-
-    expect(result).to eq('Hello !')
-  end
-end
+Langfuse.configuration
+Langfuse.client.api_client.cache
 ```
 
 ## Troubleshooting
 
 ### Prompts Not Updating
 
-If prompts aren't updating after changes in Langfuse:
+The usual problem is stale cache, not a broken prompt API.
 
-1. **Check cache TTL**: Prompts are cached. Wait for TTL to expire or restart server
-2. **Clear cache manually**: `Langfuse.client.instance_variable_get(:@api_client).cache&.clear` (in console)
-3. **Reduce cache TTL in development**: `config.cache_ttl = 10` for faster iteration
-
-### Authentication Errors
+1. Wait for `cache_ttl` to expire.
+2. Clear the cache entry store directly if you need to inspect fresh state now.
+3. Lower `cache_ttl` in development if you are iterating quickly.
 
 ```ruby
-# Verify credentials are loaded
-Rails.application.console do
-  puts "Public Key: #{Langfuse.configuration.public_key}"
-  puts "Secret Key: #{Langfuse.configuration.secret_key&.slice(0, 8)}..."
-end
+Langfuse.client.api_client.cache&.clear
 ```
 
-### High Latency
+### Traces Missing Entirely
 
-If prompt fetches are slow:
+Check the boring stuff first:
 
-1. **Enable caching**: Ensure `cache_ttl > 0`
-2. **Use fallbacks**: Provide fallback prompts for critical paths
-3. **Warm cache on boot**: Fetch frequently-used prompts in initializer
+```ruby
+Langfuse.configuration.public_key.present?
+Langfuse.configuration.secret_key.present?
+Langfuse.configuration.base_url.present?
+```
 
-### Memory Issues
+Then check the ownership assumption:
 
-If experiencing high memory usage:
+- `Langfuse.observe(...)` should work once Langfuse is configured
+- third-party ambient OpenTelemetry spans do not go to Langfuse unless you explicitly install `Langfuse.tracer_provider`
+- `should_export_span` only runs for spans handled by Langfuse's provider
 
-1. **Reduce cache_max_size**: Default is 1000, reduce if needed
-2. **Enable cache cleanup**: Implement periodic cache cleanup in background job
+### Unexpected Spans After Global Install
 
-## See Also
-
-- [Getting Started](GETTING_STARTED.md) - Installation and first trace
-- [Configuration Reference](CONFIGURATION.md) - All config options
-- [Tracing Guide](TRACING.md) - Nested spans and OpenTelemetry
-- [Migration Guide](MIGRATION.md) - Migrating from hardcoded prompts
-- [Langfuse Documentation](https://langfuse.com/docs) - Official Langfuse docs
+That means you chose the global-provider path and now Langfuse is seeing application-wide spans. That is expected. Narrow the export path with `should_export_span` if needed, but do not confuse that with the isolated default behavior.

--- a/docs/RAILS.md
+++ b/docs/RAILS.md
@@ -185,9 +185,11 @@ class DocumentsController < ApplicationController
       trace_id = trace.trace_id
       ProcessDocumentJob.perform_later(document.id, trace_id)
 
-      trace.start_observation("job-enqueued", as_type: :event) do |event|
-        event.update(input: { document_id: document.id })
-      end
+      trace.start_observation(
+        "job-enqueued",
+        { input: { document_id: document.id } },
+        as_type: :event
+      )
 
       render json: document, status: :created
     end

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,37 +1,43 @@
-# Langfuse Ruby SDK — Documentation
+# Langfuse Ruby SDK Documentation
 
-## Foundations
+This is the consumer hub. Start here unless you are already looking for a specific reference page.
 
-Core concepts you need before using any feature.
+## Start Here
 
-- **[Getting Started](GETTING_STARTED.md)** — Install the gem, configure credentials, send your first trace
-- **[Configuration](CONFIGURATION.md)** — All `Langfuse.configure` options: keys, timeouts, cache backends, SWR
+1. **[Getting Started](GETTING_STARTED.md)** — Rails-first first run: install, configure, fetch a prompt, send a real trace
+2. **[Prompts](PROMPTS.md)** — Fetch, compile, version, and fall back safely
+3. **[Tracing](TRACING.md)** — Root observations, nested generations, events, propagation, and OpenTelemetry ownership
+4. **[Scoring](SCORING.md)** — Add evaluation and feedback signals to traces and observations
+5. **[Rails](RAILS.md)** — Applied controller, service, job, testing, and operational patterns
 
-## Core Features
+## By Intent
 
-The three primitives of the SDK.
+### First Run
 
-- **[Prompts](PROMPTS.md)** — Fetch, compile, and version-manage text and chat prompts
-- **[Tracing](TRACING.md)** — Nested spans, RAG patterns, OpenTelemetry integration
-- **[Scoring](SCORING.md)** — Attach quality scores to traces and observations
+- **[Getting Started](GETTING_STARTED.md)** — The shortest path from zero to a visible prompt + trace
+- **[Prompts](PROMPTS.md)** — The next thing most consumers need after installation
+- **[Tracing](TRACING.md)** — The actual tracing lifecycle, without the hand-wavy OpenTelemetry claims
 
-## Evaluation
+### Instrument an App
 
-Systematic testing of LLM behavior.
+- **[Tracing](TRACING.md)** — Observation hierarchy, propagation, background jobs, explicit global install
+- **[Rails](RAILS.md)** — Rails-specific patterns for controllers, services, jobs, and tests
+- **[Scoring](SCORING.md)** — Capture quality signals after a trace exists
 
-- **[Datasets](DATASETS.md)** — Create and manage evaluation datasets
-- **[Experiments](EXPERIMENTS.md)** — Run evaluations against datasets with the experiment runner
+### Production Hardening
 
-## Production
+- **[Configuration](CONFIGURATION.md)** — Config surface, tracing ownership, export filtering, environment defaults
+- **[Caching](CACHING.md)** — Prompt cache backends, stale-while-revalidate, cache warming
+- **[Error Handling](ERROR_HANDLING.md)** — Failure modes, retry boundaries, debugging
+- **[Migration Guide](MIGRATION.md)** — Move hardcoded prompts into Langfuse-managed prompts without breaking runtime behavior
 
-Patterns for real-world deployments.
+### Evaluation
 
-- **[Caching](CACHING.md)** — In-memory and Rails.cache backends, SWR, stampede protection
-- **[Error Handling](ERROR_HANDLING.md)** — Exception types, retry behavior, fallback strategies
-- **[Rails Integration](RAILS.md)** — Initializers, controller tracing, testing helpers
-- **[Migration Guide](MIGRATION.md)** — Move from hardcoded prompts to Langfuse-managed prompts
+- **[Datasets](DATASETS.md)** — Dataset primitives and management
+- **[Experiments](EXPERIMENTS.md)** — Experiment runner workflows
 
-## Reference
+### Reference
 
-- **[API Reference](API_REFERENCE.md)** — Complete method reference for every public class
-- **[Architecture](ARCHITECTURE.md)** — Internal design: layers, threading, cache architecture
+- **[API Reference](API_REFERENCE.md)** — Exact public signatures and types
+- **[Configuration](CONFIGURATION.md)** — Option-by-option config reference
+- **[Architecture](ARCHITECTURE.md)** — Implementation and internal design reference, not required for the first run

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -102,10 +102,12 @@ A **point-in-time occurrence** within a span or trace. Like a log message but st
 - Metadata
 
 ```ruby
-# Event using start_observation (auto-ends immediately)
-Langfuse.observe("user-feedback", as_type: :event) do |event|
-  event.update(input: { rating: "thumbs_up", comment: "Very helpful!" })
-end
+# Standalone event observation (auto-ends immediately)
+Langfuse.observe(
+  "user-feedback",
+  input: { rating: "thumbs_up", comment: "Very helpful!" },
+  as_type: :event
+)
 
 # Event using the event method on an observation
 Langfuse.observe("operation") do |span|
@@ -247,12 +249,12 @@ def answer_question(user_id:, question:)
     end
 
     # Step 3: Log result event
-    Langfuse.observe("answer-generated", as_type: :event) do |event|
-      event.update(
-        input: { question: question },
-        output: { answer: answer, sources: documents.map(&:id) }
-      )
-    end
+    Langfuse.observe(
+      "answer-generated",
+      input: { question: question },
+      output: { answer: answer, sources: documents.map(&:id) },
+      as_type: :event
+    )
 
     answer
   end

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -1,757 +1,313 @@
 # LLM Tracing Guide
 
-Complete guide to tracing LLM applications with the Langfuse Ruby SDK.
+This guide is about the tracing behavior the SDK actually implements today. If you just need install and first-run setup, start with [GETTING_STARTED.md](GETTING_STARTED.md).
 
-For basic setup and quick start examples, see [GETTING_STARTED.md](GETTING_STARTED.md).
+## Mental Model
 
-## Table of Contents
+- A root observation becomes the root of a trace. You do not create traces separately.
+- Child observations create nested spans inside that trace.
+- `:generation` is the right type for model calls because it carries model-specific fields like `model`, `usage_details`, and `cost_details`.
+- `:event` is a point-in-time observation with no duration.
+- `Langfuse.configure` stores configuration only. Module-level tracing uses Langfuse's internal tracer provider when tracing is ready.
 
-- [Core Concepts](#core-concepts)
-- [Quick Examples](#quick-examples)
-- [Complete Examples](#complete-examples)
-- [Best Practices](#best-practices)
-- [Custom Trace IDs](#custom-trace-ids)
-- [Advanced Usage](#advanced-usage)
-- [Masking](#masking)
+## Start with a Root Observation
 
-## Core Concepts
-
-### Understanding Observations: Spans, Generations, and Events
-
-| Concept | What It Is | When to Use | Has Duration? |
-|---------|-----------|-------------|---------------|
-| **Span** | A single unit of work | Any work that has a duration (retrieval, parsing, etc.) | ✅ Yes |
-| **Generation** | A specialized span for LLM calls (Langfuse extension) | Calling an LLM (OpenAI, Anthropic, etc.) | ✅ Yes |
-| **Event** | A point-in-time occurrence | Something happened at a point in time (log, feedback, flag) | ❌ No |
-
-**Note:** In Langfuse Ruby SDK, traces are automatically created from the root observation. You don't explicitly create traces - they emerge from your observation hierarchy.
-
-### Span
-
-A **single unit of work** within a trace. Think of it as a function call or operation.
-
-**Examples:**
-- "Retrieve documents from vector DB"
-- "Parse PDF file"
-- "Call external API"
-- "Database query"
-
-**Properties:**
-- Start/end timestamps (duration calculated automatically)
-- Parent/child relationships (spans can be nested)
-- Input/output data
-- Metadata
+Most applications need one root observation per user-visible workflow.
 
 ```ruby
-Langfuse.observe("vector-search", input: { query: "What is Ruby?" }) do |span|
-  results = vector_db.search(query, limit: 5)
-  span.update(output: { count: results.size, ids: results.map(&:id) })
-  span.metadata = { db_latency_ms: 42 }
-  results
+result = Langfuse.observe("draft-summary", input: { document_id: document.id }) do |root|
+  summary = summarize_document(document)
+
+  root.update(
+    output: { summary: summary },
+    metadata: { source: "web" }
+  )
+
+  summary
 end
 ```
 
-### Generation
+This pattern does three things:
 
-A **specialized span for LLM calls**. This is NOT a standard OpenTelemetry concept - it's a Langfuse convention.
+- creates the trace entrypoint
+- gives you a place to persist workflow-level output
+- gives child work somewhere correct to hang
 
-**Why separate from regular spans?**
-- LLM calls have unique properties: model name, tokens, cost
-- Need special handling for prompt tracking
-- Want to aggregate LLM metrics separately
+## Nest Generations Inside the Workflow
 
-**Properties (in addition to span properties):**
-- Model name and version
-- Token usage (prompt, completion, total)
-- Model parameters (temperature, max_tokens, etc.)
-- Prompt information (if using Langfuse prompts)
+Use a child generation for the actual model call instead of stuffing everything into one giant root span.
 
 ```ruby
-Langfuse.observe("gpt4-call", as_type: :generation) do |gen|
-  gen.model = "gpt-4"
-  gen.input = [{ role: "user", content: "Hello" }]
-  gen.model_parameters = { temperature: 0.7, max_tokens: 500 }
-  
-  response = openai_client.chat(...)
-  
-  gen.output = response.choices.first.message.content
-  gen.usage_details = {
-    prompt_tokens: 10,
-    completion_tokens: 20,
-    total_tokens: 30
-  }
-end
-```
+Langfuse.observe("support-answer", input: { question: question }) do |root|
+  prompt = Langfuse.client.get_prompt("support-answer", label: "production")
+  messages = prompt.compile(customer_name: user.name, question: question)
 
-**Under the hood:** A generation is still a span in OpenTelemetry, but with additional LLM-specific attributes that Langfuse understands.
+  answer = root.start_observation("openai-chat", as_type: :generation) do |gen|
+    gen.model = "gpt-4.1-mini"
+    gen.input = messages
+    gen.model_parameters = { temperature: 0.2 }
 
-### Event
-
-A **point-in-time occurrence** within a span or trace. Like a log message but structured.
-
-**Examples:**
-- "Cache hit"
-- "User provided feedback"
-- "Rate limit encountered"
-- "Retry attempt"
-
-**Properties:**
-- Timestamp (automatically captured)
-- Name
-- Input/output data
-- Metadata
-
-```ruby
-# Standalone event observation (auto-ends immediately)
-Langfuse.observe(
-  "user-feedback",
-  input: { rating: "thumbs_up", comment: "Very helpful!" },
-  as_type: :event
-)
-
-# Event using the event method on an observation
-Langfuse.observe("operation") do |span|
-  span.event(name: "cache-hit", input: { key: "prompt-greeting-v2" })
-end
-```
-
-**Key difference from spans:**
-- Events have NO duration (just a timestamp)
-- Events don't have children
-- Think "something happened" vs. "doing work"
-
-### Trace-Level Attributes
-
-Trace-level attributes (user_id, session_id, metadata, tags) are set using `Langfuse.propagate_attributes()`. This ensures all observations within the context inherit these attributes. Individual tags must be strings of ≤200 characters; oversized tags are dropped with a warning.
-
-```ruby
-Langfuse.propagate_attributes(
-  user_id: "user-123",
-  session_id: "session-456",
-  metadata: { environment: "production" },
-  tags: ["api", "v2"]
-) do
-  Langfuse.observe("operation") do |span|
-    # This span and all children inherit user_id, session_id, etc.
-  end
-end
-```
-
-## Quick Examples
-
-### Basic Observation with Generation
-
-```ruby
-Langfuse.propagate_attributes(user_id: "user-123") do
-  Langfuse.observe("chat-completion", as_type: :generation) do |gen|
-    gen.model = "gpt-4"
-    gen.input = [{ role: "user", content: "Hello, how are you?" }]
-    
-    response = openai_client.chat(
+    response = llm_client.chat(
       parameters: {
-        model: "gpt-4",
-        messages: [{ role: "user", content: "Hello, how are you?" }]
+        model: "gpt-4.1-mini",
+        messages: messages,
+        temperature: 0.2
       }
     )
 
-    gen.output = response.choices.first.message.content
-    gen.usage_details = {
-      prompt_tokens: response.usage.prompt_tokens,
-      completion_tokens: response.usage.completion_tokens,
-      total_tokens: response.usage.total_tokens
-    }
-  end
-end
-```
+    answer = response.dig("choices", 0, "message", "content")
 
-### Nested Observations
-
-```ruby
-Langfuse.observe("document-processing") do |parent|
-  # Child span
-  parent.start_observation("parse-pages") do |child|
-    pages = extract_pages(pdf_file)
-    child.update(output: { page_count: pages.size })
-  end
-
-  # Another child span
-  parent.start_observation("extract-text") do |child|
-    text = extract_text(pages)
-    child.update(output: { text_length: text.length })
-  end
-end
-```
-
-## Complete Examples
-
-### RAG Pipeline with Full Instrumentation
-
-```ruby
-def answer_question(user_id:, question:)
-  Langfuse.propagate_attributes(
-    user_id: user_id,
-    metadata: { question: question, source: "web" }
-  ) do
-    # Step 1: Retrieve relevant documents
-    documents = Langfuse.observe("document-retrieval", input: { query: question }) do |span|
-      # Generate embedding for question
-      embedding = span.start_observation("embed-question", as_type: :generation) do |gen|
-        gen.model = "text-embedding-ada-002"
-        gen.input = question
-        
-        result = openai_client.embeddings(
-          parameters: { model: "text-embedding-ada-002", input: question }
-        )
-        gen.output = result.data.first.embedding
-        gen.usage_details = { total_tokens: result.usage.total_tokens }
-        result.data.first.embedding
-      end
-
-      # Search vector database
-      docs = vector_db.similarity_search(embedding, limit: 3)
-      span.update(
-        output: { doc_ids: docs.map(&:id), count: docs.size },
-        metadata: { search_latency_ms: 45 }
-      )
-      docs
-    end
-
-    # Step 2: Generate answer with LLM
-    prompt = Langfuse.client.get_prompt("qa-with-context", label: "production")
-
-    answer = Langfuse.observe("generate-answer", as_type: :generation) do |gen|
-      gen.model = "gpt-4"
-      gen.model_parameters = { temperature: 0.3, max_tokens: 500 }
-      
-      messages = prompt.compile(
-        question: question,
-        context: documents.map(&:content).join("\n\n")
-      )
-      gen.input = messages
-
-      response = openai_client.chat(
-        parameters: {
-          model: "gpt-4",
-          messages: messages,
-          temperature: 0.3,
-          max_tokens: 500
-        }
-      )
-
-      gen.output = response.choices.first.message.content
-      gen.usage_details = {
-        prompt_tokens: response.usage.prompt_tokens,
-        completion_tokens: response.usage.completion_tokens,
-        total_tokens: response.usage.total_tokens
+    gen.update(
+      output: answer,
+      usage_details: {
+        prompt_tokens: response.dig("usage", "prompt_tokens"),
+        completion_tokens: response.dig("usage", "completion_tokens"),
+        total_tokens: response.dig("usage", "total_tokens")
       }
-
-      response.choices.first.message.content
-    end
-
-    # Step 3: Log result event
-    Langfuse.observe(
-      "answer-generated",
-      input: { question: question },
-      output: { answer: answer, sources: documents.map(&:id) },
-      as_type: :event
     )
 
     answer
   end
+
+  root.update(output: { answer: answer })
 end
 ```
 
-**Visual representation:**
-```
-Trace: (auto-created from root observation)
-│
-├─ Span: document-retrieval (0.8s)
-│  ├─ Generation: embed-question (0.3s)
-│  └─ (vector search happens here)
-│
-├─ Generation: generate-answer (2.0s)
-│
-└─ Event: answer-generated (instant)
-```
+That shape is better than a flat one-span trace because it keeps workflow state on the root and model-specific state on the generation where Langfuse expects it.
 
-### Multi-Turn Conversation
+## Record Events That Actually Persist Payloads
+
+There are two patterns that work. Use them on purpose.
+
+### Standalone Event Observation
+
+If you want a payload-bearing event observation, pass the payload when you create it:
 
 ```ruby
-def chat_conversation(user_id:, session_id:, messages:)
-  Langfuse.propagate_attributes(
-    user_id: user_id,
-    session_id: session_id
-  ) do
-    # Load conversation history
-    history = Langfuse.observe("load-history") do |span|
-      history = conversation_store.get(session_id)
-      span.update(output: { message_count: history.size })
-      history
+Langfuse.observe(
+  "job-enqueued",
+  {
+    input: { document_id: document.id, queue: "default" },
+    level: "DEFAULT"
+  },
+  as_type: :event
+)
+```
+
+### Point-in-Time Annotation on an Existing Observation
+
+If you already have an active root or child observation, annotate it with `event(...)`:
+
+```ruby
+Langfuse.observe("support-answer") do |root|
+  root.event(name: "cache-hit", input: { key: "support-answer:v3" })
+end
+```
+
+### What Not to Do
+
+Do not create a standalone `:event` observation and then try to attach payload in a later block update. The event auto-ends immediately when it is created, so that payload arrives too late. If you need payload, pass it at creation time or use `root.event(...)`.
+
+## Propagate Trace-Level Attributes
+
+Use `Langfuse.propagate_attributes` for trace-level fields that should follow the current workflow.
+
+```ruby
+Langfuse.propagate_attributes(
+  user_id: current_user.id.to_s,
+  session_id: "support-session-123",
+  metadata: { environment: Rails.env },
+  tags: ["support", "chat"]
+) do
+  Langfuse.observe("support-answer") do |root|
+    root.start_observation("prompt-fetch") do |span|
+      span.update(output: { prompt_name: "support-answer" })
     end
-
-    # Get system prompt
-    prompt = Langfuse.client.get_prompt("chat-system", label: "production")
-    system_message = prompt.compile(user_name: get_user_name(user_id))
-
-    # Generate response
-    response = Langfuse.observe("chat-completion", as_type: :generation) do |gen|
-      gen.model = "gpt-4"
-      gen.input = [system_message] + history + messages
-      
-      result = openai_client.chat(
-        parameters: {
-          model: "gpt-4",
-          messages: [system_message] + history + messages
-        }
-      )
-
-      gen.output = result.choices.first.message.content
-      gen.usage_details = {
-        prompt_tokens: result.usage.prompt_tokens,
-        completion_tokens: result.usage.completion_tokens
-      }
-
-      result.choices.first.message.content
-    end
-
-    # Save to history
-    Langfuse.observe("save-history") do |span|
-      conversation_store.append(session_id, messages + [{ role: "assistant", content: response }])
-      span.update(output: { saved: true })
-    end
-
-    response
   end
 end
 ```
 
-### Error Handling and Retry Tracking
+Important boundaries:
+
+- it updates the currently active span if one exists
+- it also applies to spans created after the propagation block starts
+- it does not retroactively rewrite spans that already ended
+
+If you need cross-service propagation via OpenTelemetry baggage, use `as_baggage: true` and make sure the host app has the baggage gem and its own header propagation pipeline configured.
+
+## Background Jobs and Async Work
+
+ActiveJob or Sidekiq does not magically continue Langfuse trace context across processes. You need to pass something explicit.
+
+### Good Default: Pass the `trace_id`
+
+Controller or request path:
 
 ```ruby
-def call_llm_with_retry(prompt:, max_retries: 3)
-  Langfuse.observe("llm-with-retry") do |root|
-    attempt = 0
+Langfuse.propagate_attributes(user_id: current_user.id.to_s) do
+  Langfuse.observe("document-upload", input: { filename: upload.original_filename }) do |root|
+    document = Document.create!(file: upload)
 
-    root.start_observation("openai-call", as_type: :generation) do |gen|
-      gen.model = "gpt-4"
-      gen.input = prompt
-      
-      begin
-        attempt += 1
-        root.event(name: "attempt", input: { attempt_number: attempt })
+    ProcessDocumentJob.perform_later(document.id, root.trace_id)
+    root.event(name: "job-enqueued", input: { document_id: document.id, queue: "default" })
+  end
+end
+```
 
-        response = openai_client.chat(
-          parameters: { model: "gpt-4", messages: prompt }
-        )
+Background job:
 
-        gen.output = response.choices.first.message.content
-        gen.usage_details = {
-          prompt_tokens: response.usage.prompt_tokens,
-          completion_tokens: response.usage.completion_tokens
-        }
+```ruby
+class ProcessDocumentJob < ApplicationJob
+  def perform(document_id, trace_id)
+    document = Document.find(document_id)
 
-        response.choices.first.message.content
-      rescue OpenAI::RateLimitError => e
-        root.event(name: "rate-limit", input: { attempt: attempt, error: e.message })
+    Langfuse.observe("process-document", { input: { document_id: document_id } }, trace_id: trace_id) do |root|
+      text = root.start_observation("extract-text") do |span|
+        extracted_text = extract_text(document)
+        span.update(output: { characters: extracted_text.length })
+        extracted_text
+      end
 
-        if attempt < max_retries
-          sleep(2 ** attempt)  # Exponential backoff
-          retry
-        else
-          gen.level = "ERROR"
-          gen.update(metadata: { error: "max_retries_exceeded", attempts: attempt })
-          raise
-        end
-      rescue => e
-        gen.level = "ERROR"
-        gen.update(metadata: { error_class: e.class.name, error_message: e.message })
-        raise
+      root.start_observation("summarize", as_type: :generation) do |gen|
+        gen.model = "gpt-4.1-mini"
+        summary = summarize(text)
+        gen.update(output: summary)
+        document.update!(summary: summary)
       end
     end
   end
 end
 ```
 
-## Best Practices
+What that means:
 
-### 1. Always Capture Usage Information
+- `trace_id:` joins the same trace
+- the job creates a new root observation inside that trace
+- this is usually enough for consumer workflows
 
-```ruby
-# ✅ Good - captures token usage
-Langfuse.observe("gpt4", as_type: :generation) do |gen|
-  gen.model = "gpt-4"
-  gen.input = messages
-  
-  response = openai_client.chat(...)
-  gen.output = response.choices.first.message.content
-  gen.usage_details = {
-    prompt_tokens: response.usage.prompt_tokens,
-    completion_tokens: response.usage.completion_tokens,
-    total_tokens: response.usage.total_tokens
-  }
-end
-
-# ❌ Bad - missing usage information
-Langfuse.observe("gpt4", as_type: :generation) do |gen|
-  gen.model = "gpt-4"
-  gen.input = messages
-  
-  response = openai_client.chat(...)
-  gen.output = response.choices.first.message.content
-  # Missing: gen.usage_details = ...
-end
-```
-
-### 2. Use Descriptive Names
-
-```ruby
-# ✅ Good - clear what this does
-Langfuse.observe("retrieve-user-documents")
-
-# ❌ Bad - too generic
-Langfuse.observe("process")
-```
-
-### 3. Add Metadata for Context
-
-```ruby
-# ✅ Good - includes useful context
-Langfuse.observe("database-query") do |span|
-  results = db.query(sql)
-  span.update(
-    output: { count: results.size },
-    metadata: {
-      query_time_ms: elapsed_time,
-      rows_scanned: results.meta.rows_scanned,
-      cache_hit: false
-    }
-  )
-end
-```
-
-### 4. Link Prompts to Generations
-
-```ruby
-# ✅ Good - automatic prompt tracking
-prompt = Langfuse.client.get_prompt("greeting", version: 2)
-Langfuse.observe("greet", as_type: :generation) do |gen|
-  gen.model = "gpt-4"
-  gen.update(prompt: { name: prompt.name, version: prompt.version })
-  # Langfuse will automatically link this generation to the prompt
-end
-
-# ❌ Less useful - no prompt tracking
-Langfuse.observe("greet", as_type: :generation) do |gen|
-  gen.model = "gpt-4"
-  # Which prompt was used? What version?
-end
-```
-
-### 5. Use Events for Important Milestones
-
-```ruby
-Langfuse.propagate_attributes(user_id: "user-123") do
-  Langfuse.observe("user-onboarding") do |span|
-    span.event(name: "started", input: { source: "mobile_app" })
-
-    # ... do work ...
-
-    span.event(name: "completed", input: { duration_minutes: 5 })
-    span.event(name: "user-feedback", input: { rating: 5 })
-  end
-end
-```
-
-### 6. Set Error Levels Appropriately
-
-```ruby
-Langfuse.observe("api-call") do |span|
-  begin
-    result = external_api.call
-    span.update(output: result)
-  rescue RateLimitError => e
-    span.level = "WARNING"  # Recoverable error
-    span.update(metadata: { error: e.message, retry_after: 60 })
-  rescue => e
-    span.level = "ERROR"  # Unexpected error
-    span.update(metadata: { error_class: e.class.name, error: e.message })
-    raise
-  end
-end
-```
-
-### 7. Use propagate_attributes Early
-
-```ruby
-# ✅ Good - attributes propagate to all observations
-Langfuse.propagate_attributes(user_id: "user-123", session_id: "session-456") do
-  Langfuse.observe("operation") do |span|
-    span.start_observation("child") do |child|
-      # Child inherits user_id and session_id
-    end
-  end
-end
-
-# ❌ Less ideal - attributes only on specific observations
-Langfuse.observe("operation") do |span|
-  span.update_trace(user_id: "user-123", session_id: "session-456")
-  # Only this span has the attributes, not children created before this call
-end
-```
+If you need true parent-child continuation across process or service boundaries, that is host-application OpenTelemetry context propagation work. Langfuse does not do that wiring for you automatically.
 
 ## Custom Trace IDs
 
-By default, Langfuse generates random trace IDs. Custom trace IDs let you control the trace identity — useful when you need to reference a trace later from a different part of your system.
-
-### When to Use Custom Trace IDs
-
-- **Background job scoring** — a web request creates a trace, a worker scores it hours later
-- **Cross-service correlation** — multiple services contribute to the same logical trace
-- **Idempotent retries** — reprocessing the same input lands on the same trace
-- **External ID correlation** — link Langfuse traces to your database rows without storing trace IDs
-
-### Deterministic Trace IDs from Seeds
-
-Generate the same trace ID from the same seed, every time, across Ruby, Python, and JS SDKs:
+Use custom trace IDs when your application already has a durable identifier you want to correlate with Langfuse.
 
 ```ruby
-trace_id = Langfuse.create_trace_id(seed: "order-42")
-# => "3bf8b157c4238eefe5ae4a66eca81c6b"
+trace_id = Langfuse.create_trace_id(seed: "order-#{order.id}")
 
-# Same seed, same ID — even from a different process
-trace_id_again = Langfuse.create_trace_id(seed: "order-42")
-# => "3bf8b157c4238eefe5ae4a66eca81c6b"
-```
-
-Under the hood: `SHA-256(seed)[0..15]` → 32-char lowercase hex. This matches the Python SDK's `Langfuse.create_trace_id(seed=...)` and the JS SDK's `createTraceId(seed)`.
-
-> [!IMPORTANT]
-> Seeds must be **String** values. Passing non-String types (integers, symbols) raises `ArgumentError`. This ensures cross-SDK parity — Python and JS also reject non-strings.
-
-> [!WARNING]
-> Do not pass PII, secrets, or credentials as seeds. The seed itself appears in your application code and may leak through logs and backtraces. Use stable, non-sensitive identifiers: database primary keys, UUIDs, or request IDs.
-
-### Using Custom Trace IDs
-
-Pass `trace_id:` to `observe` or `start_observation`:
-
-```ruby
-trace_id = Langfuse.create_trace_id(seed: "order-42")
-
-# Block-based
-Langfuse.observe("process-order", trace_id: trace_id) do |span|
-  span.update_trace(user_id: "user-123", tags: ["orders"])
-  result = process_order(42)
-  span.update(output: result)
-end
-
-# Stateful
-obs = Langfuse.observe("process-order", trace_id: trace_id)
-obs.update(output: { status: "done" })
-obs.end
-```
-
-You can also use a pre-generated hex trace ID directly (must be 32 lowercase hex characters):
-
-```ruby
-# ✅ Good — valid 32-char lowercase hex
-Langfuse.observe("op", trace_id: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4") { ... }
-
-# ❌ Bad — not valid hex format
-Langfuse.observe("op", trace_id: "my-custom-id") { ... }
-# => ArgumentError: Invalid trace_id
-```
-
-### Complete Example: Web Request + Background Scoring
-
-```ruby
-# === Web server ===
-class OrdersController < ApplicationController
-  def create
-    order = Order.create!(params)
-
-    # Deterministic trace ID from order's primary key
-    trace_id = Langfuse.create_trace_id(seed: "order-#{order.id}")
-
-    Langfuse.observe("process-order", trace_id: trace_id) do |span|
-      span.update_trace(user_id: current_user.id, tags: ["orders"])
-
-      span.start_observation("validate", input: order.attributes) do |child|
-        child.update(output: { valid: true })
-      end
-
-      span.start_observation("llm-summarize", as_type: :generation) do |gen|
-        gen.model = "gpt-4"
-        gen.input = [{ role: "user", content: "Summarize: #{order.description}" }]
-        summary = call_llm(gen.input)
-        gen.update(output: summary, usage_details: { input: 50, output: 20 })
-      end
-    end
-
-    # No need to store trace_id — it can be recomputed from order.id
-    render json: order
-  end
-end
-
-# === Background worker (hours later) ===
-class OrderQualityJob
-  def perform(order_id)
-    # Recompute the same trace ID — no database lookup needed
-    trace_id = Langfuse.create_trace_id(seed: "order-#{order_id}")
-
-    score = evaluate_order_quality(order_id)
-
-    Langfuse.create_score(
-      name: "order_quality",
-      value: score,
-      trace_id: trace_id,
-      data_type: :numeric,
-      comment: "Async quality evaluation"
-    )
-  end
+Langfuse.observe("process-order", trace_id: trace_id, input: { order_id: order.id }) do |root|
+  root.update(output: { status: "processed" })
 end
 ```
 
-## Advanced Usage
+Good use cases:
 
-### Custom Observability Levels
+- retries that should land on the same logical trace
+- linking traces to a durable application record
+- async workflows where a later worker needs to rejoin the trace
 
-```ruby
-Langfuse.observe("production-query") do |root|
-  # Debug-level span (only in development/staging)
-  root.start_observation("cache-check") do |span|
-    span.level = "DEBUG"
-    # ... cache logic
-  end
+Do not use secrets or raw PII as seeds.
 
-  # Default-level generation (always tracked)
-  root.start_observation("llm-call", as_type: :generation) do |gen|
-    gen.model = "gpt-4"
-    gen.level = "DEFAULT"
-    # ... LLM call
-  end
+## OpenTelemetry Integration
 
-  # Warning-level event (important but not error)
-  if cache_miss_rate > 0.8
-    root.event(name: "high-cache-miss-rate", input: { rate: cache_miss_rate })
-    root.level = "WARNING"
-  end
-end
-```
+There are three states. Keep them separate in your head or you will misconfigure this.
 
-### Background Jobs and Async Processing
+### 1. Default Isolated Langfuse Tracing
 
-```ruby
-# In controller - create observation and pass trace context
-Langfuse.propagate_attributes(user_id: current_user.id) do
-  Langfuse.observe("document-upload") do |span|
-    document = Document.create!(params)
-    
-    # Get trace context to pass to background job
-    trace_id = span.trace_id
-    
-    ProcessDocumentJob.perform_later(document.id, trace_id)
-    
-    span.event(name: "job-enqueued", input: { document_id: document.id })
-  end
-end
+This is the default behavior:
 
-# Background job - continue trace
-class ProcessDocumentJob < ApplicationJob
-  def perform(document_id, trace_id = nil)
-    # Note: Cross-process trace continuation requires additional setup
-    # For now, create a new observation with metadata linking to original trace
-    Langfuse.propagate_attributes(metadata: { original_trace_id: trace_id }) do
-      Langfuse.observe("process-document") do |span|
-        span.start_observation("extract-text") do |child|
-          text = extract_text(document_id)
-          child.update(output: { text_length: text.length })
-        end
+- `Langfuse.configure` does not mutate `OpenTelemetry.tracer_provider`
+- `Langfuse.configure` does not mutate `OpenTelemetry.propagation`
+- `Langfuse.observe(...)` uses Langfuse's internal tracer provider once tracing is configured
+- if tracing config is incomplete, module-level tracing falls back to a no-op tracer and logs one warning
 
-        span.start_observation("summarize", as_type: :generation) do |gen|
-          gen.model = "gpt-4"
-          summary = generate_summary(text)
-          gen.update(output: summary)
-        end
-      end
-    end
-  end
-end
-```
+This is why ambient spans from some unrelated global OpenTelemetry provider are not exported to Langfuse by default.
 
-### Stateful API (Manual End)
+### 2. Explicit Global Install with `Langfuse.tracer_provider`
 
-```ruby
-# Create observation without block
-span = Langfuse.observe("long-running-operation", input: { query: "test" })
-
-# Do work...
-result = perform_operation
-
-# Update and end manually
-span.update(output: result, metadata: { duration_ms: 150 })
-span.end
-```
-
-### Using update() Method
-
-```ruby
-# ✅ Good - using update() method
-Langfuse.observe("operation") do |span|
-  span.update(
-    output: { result: "success" },
-    metadata: { duration_ms: 150 },
-    level: "DEFAULT"
-  )
-end
-
-# ✅ Also good - using setters
-Langfuse.observe("operation") do |span|
-  span.output = { result: "success" }
-  span.metadata = { duration_ms: 150 }
-  span.level = "DEFAULT"
-end
-```
-
-### Specialized Observation Types
-
-The SDK supports several specialized observation types beyond spans and generations:
-
-- **Agent** (`as_type: :agent`) - For agent-based workflows
-- **Tool** (`as_type: :tool`) - For tool/function calls
-- **Chain** (`as_type: :chain`) - For multi-step workflows
-- **Retriever** (`as_type: :retriever`) - For document retrieval
-- **Evaluator** (`as_type: :evaluator`) - For quality assessment
-- **Guardrail** (`as_type: :guardrail`) - For safety checks
-- **Embedding** (`as_type: :embedding`) - For embedding generation
-
-```ruby
-# Example: Agent workflow
-Langfuse.observe("agent-workflow", as_type: :agent) do |agent|
-  agent.update(input: { task: "Find weather for NYC" })
-  
-  agent.start_observation("tool-call", as_type: :tool) do |tool|
-    weather = fetch_weather("NYC")
-    tool.update(output: weather)
-  end
-  
-  agent.update(output: { result: "Sunny, 72°F" })
-end
-```
-
-## Masking
-
-Mask sensitive data in `input`, `output`, and `metadata` fields before they are sent to Langfuse. Configure a mask callable on `Langfuse.configuration.mask` — it applies to all traces, observations, events, and propagated metadata.
-
-### Setup
+If you want Langfuse to own the global OpenTelemetry provider, install it explicitly:
 
 ```ruby
 Langfuse.configure do |config|
-  config.public_key = ENV['LANGFUSE_PUBLIC_KEY']
-  config.secret_key = ENV['LANGFUSE_SECRET_KEY']
+  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
+end
+
+OpenTelemetry.tracer_provider = Langfuse.tracer_provider
+```
+
+That is an ownership decision, not a free convenience:
+
+- spans created through the global provider now run through Langfuse's provider
+- `should_export_span` now applies to those spans because Langfuse is actually processing them
+- if you call `Langfuse.shutdown` or `Langfuse.reset!`, you own reinstalling the provider afterward
+
+If your app also needs W3C propagation or baggage propagation, configure `OpenTelemetry.propagation` yourself. Langfuse does not install that for you.
+
+### 3. Additional OpenTelemetry Backends Are Application-Owned
+
+Langfuse does not automatically configure multi-destination OpenTelemetry export.
+
+If you want Langfuse plus another OTel backend, wire that in explicitly in your application:
+
+- add more processors/exporters to the provider you own
+- or build and manage your own provider pipeline
+
+What Langfuse will not do for you:
+
+- replace your app's exporter topology automatically
+- install a second backend by default
+- infer whether you want multi-export just because you called `Langfuse.configure`
+
+## Export Filtering
+
+`config.should_export_span` is a filter on spans handled by Langfuse's provider. That is it.
+
+```ruby
+Langfuse.configure do |config|
+  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
+  config.should_export_span = lambda { |span|
+    Langfuse.default_export_span?(span) &&
+      span.instrumentation_scope&.name != "my_framework.worker"
+  }
+end
+```
+
+Use it when you want to narrow what Langfuse exports after Langfuse owns the provider path.
+
+Do not pretend filtering is the fix for ambient-span overcapture. Isolation is the fix. The default isolated setup already prevents random global spans from leaking into Langfuse.
+
+Public helper predicates:
+
+- `Langfuse.default_export_span?`
+- `Langfuse.langfuse_span?`
+- `Langfuse.genai_span?`
+- `Langfuse.known_llm_instrumentor?`
+- compatibility aliases: `Langfuse.is_default_export_span`, `Langfuse.is_langfuse_span`, `Langfuse.is_genai_span`, `Langfuse.is_known_llm_instrumentor`
+
+The exact signatures live in [API_REFERENCE.md](API_REFERENCE.md).
+
+## Best Practices
+
+- Put workflow-level output on the root observation and model-level output on the generation.
+- Capture `usage_details` on every generation you care about.
+- Use descriptive observation names tied to real workflow steps.
+- Use `Langfuse.propagate_attributes` early, before you start child observations.
+- Keep `should_export_span` allocation-light and side-effect free.
+- Add scores only after you have a stable trace flow. See [SCORING.md](SCORING.md).
+
+## Masking
+
+If inputs or outputs contain sensitive data, configure `mask` and let the SDK redact values before serialization:
+
+```ruby
+Langfuse.configure do |config|
+  config.public_key = ENV["LANGFUSE_PUBLIC_KEY"]
+  config.secret_key = ENV["LANGFUSE_SECRET_KEY"]
   config.mask = lambda { |data:|
-    if data.is_a?(Hash)
-      data.transform_values { |v| v.is_a?(String) ? "[REDACTED]" : v }
+    case data
+    when Hash
+      data.transform_values { "[REDACTED]" }
     else
       "[REDACTED]"
     end
@@ -759,129 +315,4 @@ Langfuse.configure do |config|
 end
 ```
 
-### Contract
-
-The mask callable must:
-
-- Accept a `data:` keyword argument (the raw field value — Hash, String, Array, etc.)
-- Return the masked version (must be JSON-serializable)
-
-```ruby
-# Lambda
-config.mask = ->(data:) { data.is_a?(Hash) ? data.except(:api_key, :token) : data }
-
-# Method object
-config.mask = method(:my_masking_function)
-
-# Any object responding to #call
-config.mask = MyMaskingService.new
-```
-
-### What Gets Masked
-
-Masking applies to three fields at every callsite:
-
-| Field      | Trace | Observation | Event | Propagated |
-|------------|-------|-------------|-------|------------|
-| `input`    | ✅    | ✅          | ✅    | —          |
-| `output`   | ✅    | ✅          | —     | —          |
-| `metadata` | ✅    | ✅          | —     | ✅         |
-
-Fields like `model`, `name`, `tags`, `environment`, and `usage_details` are **not** masked.
-
-### Fail-Closed Behavior
-
-If the mask callable raises an exception, the entire field is replaced with:
-
-```
-<fully masked due to failed mask function>
-```
-
-A warning is logged. No sensitive data leaks — the SDK is fail-closed by design.
-
-### Example: PII Redaction
-
-```ruby
-PII_KEYS = %w[email phone ssn api_key token password secret].freeze
-
-config.mask = lambda { |data:|
-  case data
-  when Hash
-    data.each_with_object({}) do |(k, v), masked|
-      masked[k] = PII_KEYS.any? { |pii| k.to_s.downcase.include?(pii) } ? "[PII]" : v
-    end
-  when String
-    data.gsub(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z]{2,}\b/i, "[EMAIL]")
-  else
-    data
-  end
-}
-```
-
-## OpenTelemetry Integration
-
-The SDK is built on OpenTelemetry, which provides:
-
-### Automatic Context Propagation
-
-Trace context automatically flows through:
-- HTTP requests (via headers)
-- Background jobs (if properly configured)
-- Database queries (with OTel instrumentation)
-- Redis operations (with OTel instrumentation)
-
-### APM Integration
-
-Traces can be exported to multiple observability platforms:
-
-```ruby
-# config/initializers/langfuse.rb
-require 'opentelemetry/sdk'
-require 'langfuse'
-
-Langfuse.configure do |config|
-  config.public_key = ENV['LANGFUSE_PUBLIC_KEY']
-  config.secret_key = ENV['LANGFUSE_SECRET_KEY']
-  config.base_url = ENV.fetch('LANGFUSE_BASE_URL', 'https://cloud.langfuse.com')
-end
-```
-
-Your traces will appear in:
-- Langfuse (for LLM-specific analytics)
-- Any OpenTelemetry-compatible platform
-
-### W3C Trace Context
-
-Langfuse spans are compatible with the [W3C Trace Context](https://www.w3.org/TR/trace-context/) standard for distributed tracing, but the SDK does not install a global propagator for you. If you want cross-service propagation, configure `OpenTelemetry.propagation` in your application:
-
-```ruby
-require "opentelemetry/trace/propagation/trace_context"
-
-OpenTelemetry.propagation =
-  OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator.new
-```
-
-That global OpenTelemetry propagator is separate from `Langfuse::Propagation`, which handles Langfuse-specific trace attributes and optional baggage propagation.
-
-With an application-configured propagator, traces can flow across services using headers like:
-
-```
-traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
-```
-
-This allows traces to flow seamlessly across:
-- Ruby services
-- Node.js services
-- Python services
-- Go services
-- Any service that implements W3C Trace Context
-
-## See Also
-
-- [Scoring Guide](SCORING.md) - Add quality scores to traces
-- [Prompts Guide](PROMPTS.md) - Managed prompts with tracing integration
-- [Rails Integration](RAILS.md) - Controller-level tracing patterns
-- [API Reference](API_REFERENCE.md) - Complete method reference
-- [Langfuse Documentation](https://langfuse.com/docs)
-- [OpenTelemetry Ruby Documentation](https://opentelemetry.io/docs/instrumentation/ruby/)
-- [W3C Trace Context Specification](https://www.w3.org/TR/trace-context/)
+Masking applies to observation `input`, `output`, and `metadata`. The full configuration contract is in [CONFIGURATION.md](CONFIGURATION.md#mask).

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -833,13 +833,14 @@ Trace context automatically flows through:
 Traces can be exported to multiple observability platforms:
 
 ```ruby
-# config/initializers/opentelemetry.rb
+# config/initializers/langfuse.rb
 require 'opentelemetry/sdk'
-require 'langfuse-rb/otel_setup'
+require 'langfuse'
 
-Langfuse::OtelSetup.configure do |config|
-  config.service_name = 'my-rails-app'
-  config.service_version = ENV['APP_VERSION']
+Langfuse.configure do |config|
+  config.public_key = ENV['LANGFUSE_PUBLIC_KEY']
+  config.secret_key = ENV['LANGFUSE_SECRET_KEY']
+  config.base_url = ENV.fetch('LANGFUSE_BASE_URL', 'https://cloud.langfuse.com')
 end
 ```
 


### PR DESCRIPTION
## Summary
- align docs examples and defaults with current SDK behavior in `lib/`
- fix invalid require paths and stale setup snippets
- correct cache/SWR and trace URL guidance to match runtime behavior

## Fixes addressed
- `docs/GETTING_STARTED.md`: use `require 'langfuse'`, document SWR activation via `cache_stale_ttl`, fix trace URL example path
- `docs/TRACING.md`: replace nonexistent `Langfuse::OtelSetup.configure` usage with supported `Langfuse.configure` snippet
- `docs/RAILS.md`: replace invalid `Langfuse.client.cache_stats` example with `Langfuse::CacheWarmer.new.cache_stats`
- `docs/API_REFERENCE.md`: fix `environment` and `release` default descriptions to include env-derived defaults

## Validation checklist
- [x] `npx --yes langfuse-cli api __schema`
- [x] `npx --yes langfuse-cli api prompts get --help`
- [ ] `bundle exec rspec` (blocked: local Bundler executable mismatch)
- [ ] `bundle exec rubocop` (blocked: local Bundler executable mismatch)
