### PR TITLE
docs: require scratchpad verification script per PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This repository is the official `langfuse-rb` SDK for LLM tracing, observability
 - Keep the SDK framework-agnostic (no Rails dependency).
 - Do not delete existing inline comments unless code changes make them invalid.
 - After any change, validate output/expectations against the Langfuse API using the installed `langfuse` agent skill (see `.agents/skills/langfuse/`).
+- Every PR must include a verification script in `scratchpad/` that exercises the change against the real Langfuse API (via the `langfuse` agent skill / CLI). Mocks and unit tests don't catch API-shape regressions — the scratchpad script does. `scratchpad/` is untracked, so the script ships with the PR locally but is not committed.
 - After any change, run:
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ bundle exec rubocop
 ```
 
 - After any change, validate output/expectations against the Langfuse API using the `langfuse` skill (`.claude/skills/langfuse/`).
+- Every PR must include a verification script in `scratchpad/` that exercises the change against the real Langfuse API (via the `langfuse` skill / CLI). Mocks and unit tests don't catch API-shape regressions — the scratchpad script does. `scratchpad/` is untracked, so the script lives alongside the PR but is not committed.
 
 ## Hard Constraints
 


### PR DESCRIPTION
#### `TL;DR`
Add guidance to `AGENTS.md` and `CLAUDE.md` that every PR must include a verification script in `scratchpad/` exercising the change against the real Langfuse API.

#### `Why`
Mocks and unit tests miss API-shape regressions (wrong field names, shifted response structure, auth edge cases). We already ship a `langfuse` skill with CLI access to the real API, and `scratchpad/` is already untracked and stocked with similar one-off verifiers (`test_traces.rb`, `verify_trace_id.rb`, etc.) — this just codifies the convention so it happens on every PR instead of ad-hoc.

#### `Checklist`
- [x] Has label
- [ ] Has linked issue
- [ ] Tests added for new behavior — N/A (docs only)
- [x] Docs updated (if user-facing)