### PR TITLE
fix(prompts): suppress fallback prompt attribution

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -434,6 +434,7 @@ Returned by `get_prompt` for text prompts.
 | `tags`    | Array<String> | Tags                   |
 | `config`  | Hash          | Prompt config hash returned by Langfuse |
 | `prompt`  | String        | Raw template           |
+| `is_fallback` | Boolean  | Whether the client uses caller-provided fallback content |
 
 **Methods:**
 

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -44,6 +44,7 @@ prompt.labels     # => ["production"]
 prompt.tags       # => ["marketing", "seo"]
 prompt.config     # => { "temperature" => 0.7, "model" => "gpt-4" }
 prompt.prompt     # => "Write a {{tone}} product description for {{product_name}}..."
+prompt.is_fallback # => false
 ```
 
 ### Compiling Text Prompts

--- a/lib/langfuse/chat_prompt_client.rb
+++ b/lib/langfuse/chat_prompt_client.rb
@@ -38,11 +38,15 @@ module Langfuse
     # @return [Array<Hash>] Array of message hashes with role and content
     attr_reader :prompt
 
+    # @return [Boolean] Whether this client uses caller-provided fallback content
+    attr_reader :is_fallback
+
     # Initialize a new chat prompt client
     #
     # @param prompt_data [Hash] The prompt data from the API
+    # @param is_fallback [Boolean] Whether this client wraps caller-provided fallback content
     # @raise [ArgumentError] if prompt data is invalid
-    def initialize(prompt_data)
+    def initialize(prompt_data, is_fallback: false)
       validate_prompt_data!(prompt_data)
 
       @name = prompt_data["name"]
@@ -51,6 +55,7 @@ module Langfuse
       @labels = prompt_data["labels"] || []
       @tags = prompt_data["tags"] || []
       @config = prompt_data["config"] || {}
+      @is_fallback = is_fallback
     end
 
     # Compile the chat prompt with variable substitution

--- a/lib/langfuse/client.rb
+++ b/lib/langfuse/client.rb
@@ -823,9 +823,9 @@ module Langfuse
 
       case type
       when :text
-        TextPromptClient.new(prompt_data)
+        TextPromptClient.new(prompt_data, is_fallback: true)
       when :chat
-        ChatPromptClient.new(prompt_data)
+        ChatPromptClient.new(prompt_data, is_fallback: true)
       end
     end
 

--- a/lib/langfuse/otel_attributes.rb
+++ b/lib/langfuse/otel_attributes.rb
@@ -302,11 +302,10 @@ module Langfuse
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def self.add_prompt_attributes(otel_attributes, prompt)
       return unless prompt
+      return if fallback_prompt?(prompt)
 
       # Handle hash-like prompts
       if prompt.is_a?(Hash) || prompt.respond_to?(:[])
-        return if prompt[:is_fallback] || prompt["is_fallback"]
-
         otel_attributes[OBSERVATION_PROMPT_NAME] = prompt[:name] || prompt["name"]
         otel_attributes[OBSERVATION_PROMPT_VERSION] = prompt[:version] || prompt["version"]
       # Handle objects with name/version methods (already converted in Trace#generation)
@@ -315,6 +314,14 @@ module Langfuse
         otel_attributes[OBSERVATION_PROMPT_VERSION] = prompt.version
       end
     end
+
+    def self.fallback_prompt?(prompt)
+      return true if prompt.respond_to?(:is_fallback) && prompt.is_fallback
+      return false unless prompt.is_a?(Hash) || prompt.respond_to?(:[])
+
+      prompt[:is_fallback] || prompt["is_fallback"]
+    end
+    private_class_method :fallback_prompt?
   end
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ModuleLength
 end

--- a/lib/langfuse/otel_attributes.rb
+++ b/lib/langfuse/otel_attributes.rb
@@ -304,7 +304,6 @@ module Langfuse
       return unless prompt
       return if fallback_prompt?(prompt)
 
-      # Handle hash-like prompts
       if prompt.is_a?(Hash) || prompt.respond_to?(:[])
         otel_attributes[OBSERVATION_PROMPT_NAME] = prompt[:name] || prompt["name"]
         otel_attributes[OBSERVATION_PROMPT_VERSION] = prompt[:version] || prompt["version"]
@@ -314,14 +313,16 @@ module Langfuse
         otel_attributes[OBSERVATION_PROMPT_VERSION] = prompt.version
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
+    # @api private
     def self.fallback_prompt?(prompt)
       return true if prompt.respond_to?(:is_fallback) && prompt.is_fallback
-      return false unless prompt.is_a?(Hash) || prompt.respond_to?(:[])
+      return false unless prompt.is_a?(Hash)
 
-      prompt[:is_fallback] || prompt["is_fallback"]
+      !!get_hash_value(prompt, :is_fallback)
     end
     private_class_method :fallback_prompt?
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ModuleLength
+  # rubocop:enable Metrics/ModuleLength
 end

--- a/lib/langfuse/text_prompt_client.rb
+++ b/lib/langfuse/text_prompt_client.rb
@@ -38,11 +38,15 @@ module Langfuse
     # @return [String] Raw prompt template string
     attr_reader :prompt
 
+    # @return [Boolean] Whether this client uses caller-provided fallback content
+    attr_reader :is_fallback
+
     # Initialize a new text prompt client
     #
     # @param prompt_data [Hash] The prompt data from the API
+    # @param is_fallback [Boolean] Whether this client wraps caller-provided fallback content
     # @raise [ArgumentError] if prompt data is invalid
-    def initialize(prompt_data)
+    def initialize(prompt_data, is_fallback: false)
       validate_prompt_data!(prompt_data)
 
       @name = prompt_data["name"]
@@ -51,6 +55,7 @@ module Langfuse
       @labels = prompt_data["labels"] || []
       @tags = prompt_data["tags"] || []
       @config = prompt_data["config"] || {}
+      @is_fallback = is_fallback
     end
 
     # Compile the prompt with variable substitution

--- a/spec/langfuse/base_observation_spec.rb
+++ b/spec/langfuse/base_observation_spec.rb
@@ -470,6 +470,25 @@ RSpec.describe Langfuse::BaseObservation do
       expect(span_data.attributes["langfuse.observation.prompt.name"]).to eq("test_prompt")
       expect(span_data.attributes["langfuse.observation.prompt.version"]).to eq(42)
     end
+
+    it "skips fallback prompt clients when starting observations" do
+      prompt = Langfuse::TextPromptClient.new(
+        {
+          "name" => "fallback_prompt",
+          "version" => 0,
+          "prompt" => "Hello {{name}}!",
+          "labels" => [],
+          "tags" => ["fallback"],
+          "config" => {}
+        },
+        is_fallback: true
+      )
+      child = observation.start_observation("test", { prompt: prompt }, as_type: :generation)
+      span_data = child.otel_span.to_span_data
+
+      expect(span_data.attributes).not_to have_key("langfuse.observation.prompt.name")
+      expect(span_data.attributes).not_to have_key("langfuse.observation.prompt.version")
+    end
   end
 
   describe "Generation setters" do
@@ -534,6 +553,26 @@ RSpec.describe Langfuse::BaseObservation do
     it "returns self from update" do
       result = generation.update({ output: "test" })
       expect(result).to eq(generation)
+    end
+
+    it "skips fallback prompt clients when updating observations" do
+      prompt = Langfuse::TextPromptClient.new(
+        {
+          "name" => "fallback_prompt",
+          "version" => 0,
+          "prompt" => "Hello {{name}}!",
+          "labels" => [],
+          "tags" => ["fallback"],
+          "config" => {}
+        },
+        is_fallback: true
+      )
+
+      generation.update({ prompt: prompt })
+      span_data = generation.otel_span.to_span_data
+
+      expect(span_data.attributes).not_to have_key("langfuse.observation.prompt.name")
+      expect(span_data.attributes).not_to have_key("langfuse.observation.prompt.version")
     end
   end
 

--- a/spec/langfuse/chat_prompt_client_spec.rb
+++ b/spec/langfuse/chat_prompt_client_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe Langfuse::ChatPromptClient do
       expect(client.prompt).to eq(prompt_data["prompt"])
     end
 
+    it "defaults is_fallback to false" do
+      client = described_class.new(prompt_data)
+      expect(client.is_fallback).to be(false)
+    end
+
+    it "sets is_fallback when explicitly provided" do
+      client = described_class.new(prompt_data, is_fallback: true)
+      expect(client.is_fallback).to be(true)
+    end
+
     it "sets the labels" do
       client = described_class.new(prompt_data)
       expect(client.labels).to eq(%w[production support])

--- a/spec/langfuse/client_spec.rb
+++ b/spec/langfuse/client_spec.rb
@@ -248,6 +248,7 @@ RSpec.describe Langfuse::Client do
         expect(result.name).to eq("greeting")
         expect(result.version).to eq(1)
         expect(result.prompt).to eq("Hello {{name}}!")
+        expect(result.is_fallback).to be(false)
       end
     end
 
@@ -287,6 +288,7 @@ RSpec.describe Langfuse::Client do
         expect(result.name).to eq("chat-assistant")
         expect(result.version).to eq(2)
         expect(result.prompt).to be_an(Array)
+        expect(result.is_fallback).to be(false)
       end
     end
 
@@ -509,6 +511,7 @@ RSpec.describe Langfuse::Client do
           expect(result.name).to eq("missing")
           expect(result.version).to eq(0)
           expect(result.tags).to include("fallback")
+          expect(result.is_fallback).to be(true)
         end
 
         it "raises error when no fallback provided" do
@@ -583,6 +586,7 @@ RSpec.describe Langfuse::Client do
           expect(result.name).to eq("chat-bot")
           expect(result.version).to eq(0)
           expect(result.tags).to include("fallback")
+          expect(result.is_fallback).to be(true)
         end
       end
 

--- a/spec/langfuse/otel_attributes_spec.rb
+++ b/spec/langfuse/otel_attributes_spec.rb
@@ -461,6 +461,47 @@ RSpec.describe Langfuse::OtelAttributes do
       expect(result).not_to have_key("langfuse.observation.prompt.version")
     end
 
+    it "skips prompt linking for fallback prompt clients" do
+      prompt = Langfuse::TextPromptClient.new(
+        {
+          "name" => "greeting",
+          "version" => 0,
+          "prompt" => "Hello {{name}}!",
+          "labels" => [],
+          "tags" => ["fallback"],
+          "config" => {}
+        },
+        is_fallback: true
+      )
+      attrs = Langfuse::Types::GenerationAttributes.new(model: "gpt-4", prompt: prompt)
+
+      result = described_class.create_observation_attributes("generation", attrs)
+
+      expect(result).not_to have_key("langfuse.observation.prompt.name")
+      expect(result).not_to have_key("langfuse.observation.prompt.version")
+    end
+
+    it "handles prompt clients when is_fallback is false" do
+      prompt = Langfuse::TextPromptClient.new(
+        {
+          "name" => "greeting",
+          "version" => 2,
+          "prompt" => "Hello {{name}}!",
+          "labels" => [],
+          "tags" => [],
+          "config" => {}
+        }
+      )
+      attrs = Langfuse::Types::GenerationAttributes.new(model: "gpt-4", prompt: prompt)
+
+      result = described_class.create_observation_attributes("generation", attrs)
+
+      expect(result).to include(
+        "langfuse.observation.prompt.name" => "greeting",
+        "langfuse.observation.prompt.version" => 2
+      )
+    end
+
     it "handles prompt with string keys" do
       attrs = {
         model: "gpt-4",

--- a/spec/langfuse/text_prompt_client_spec.rb
+++ b/spec/langfuse/text_prompt_client_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe Langfuse::TextPromptClient do
       expect(client.prompt).to eq("Hello {{name}}!")
     end
 
+    it "defaults is_fallback to false" do
+      client = described_class.new(prompt_data)
+      expect(client.is_fallback).to be(false)
+    end
+
+    it "sets is_fallback when explicitly provided" do
+      client = described_class.new(prompt_data, is_fallback: true)
+      expect(client.is_fallback).to be(true)
+    end
+
     it "sets the labels" do
       client = described_class.new(prompt_data)
       expect(client.labels).to eq(["production"])


### PR DESCRIPTION
#### `TL;DR`
Suppress prompt name/version attribution for fallback prompt clients while preserving attribution for normal prompt clients.

#### `Why`
Fallback content is caller-provided recovery content, not a managed prompt version. Emitting prompt version 0 makes fallback output look like a real prompt version downstream.

#### `Checklist`
- [x] Has label
- [x] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)


Summary
- Added an explicit is_fallback reader to text and chat prompt clients.
- Marked fallback prompt clients during fallback construction and skipped prompt attribution when that flag is set.
- Added regressions for client construction, attribute serialization, start_observation, and generation.update.
- Documented the new prompt-client property.

Validation
- rbenv exec bundle exec rspec
- rbenv exec bundle exec rubocop
- npx langfuse-cli api traces get --json --fields core,observations 356cd61f23a67f253570b927997e9c14 | jq -e '.body.observations[0].metadata.attributes | has("langfuse.observation.prompt.name") | not'
- npx langfuse-cli api traces get --json --fields core,observations 356cd61f23a67f253570b927997e9c14 | jq -e '.body.observations[0].metadata.attributes | has("langfuse.observation.prompt.version") | not'
- npx langfuse-cli api traces get --json --fields core,observations 88d90f944bd25900ee2f0cfcfe6937c9 | jq -e '.body.observations[0].metadata.attributes["langfuse.observation.prompt.name"] == "codex_normal_prompt_aai74-1777336710"'
- npx langfuse-cli api traces get --json --fields core,observations 88d90f944bd25900ee2f0cfcfe6937c9 | jq -e '.body.observations[0].metadata.attributes["langfuse.observation.prompt.version"] == "7"'
