### PR TITLE
fix(prompts): preserve chat prompt placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Preserve and compile chat prompt message placeholders in parity with Langfuse Python and JS SDKs.
+
 ## [0.8.0] - 2026-04-24
 
 ### Added

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -474,6 +474,7 @@ For Langfuse message placeholders:
 - `placeholder_name: [{ role: :user, content: "..." }]` inserts those messages.
 - `placeholder_name: []` skips the placeholder.
 - Omitting a placeholder keeps `{ type: "placeholder", name: "..." }` in the output and logs a warning.
+- Malformed placeholder values raise `ArgumentError` during compile.
 - Extra message fields are preserved when placeholder messages are inserted.
 
 **Example:**

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -467,15 +467,27 @@ Returned by `get_prompt` for chat prompts.
 compile(**variables) # => Array<Hash>
 ```
 
-Compiles template, returns array of message hashes.
+Compiles template variables and message placeholders, returning an array of message hashes.
+
+For Langfuse message placeholders:
+
+- `placeholder_name: [{ role: :user, content: "..." }]` inserts those messages.
+- `placeholder_name: []` skips the placeholder.
+- Omitting a placeholder keeps `{ type: "placeholder", name: "..." }` in the output and logs a warning.
+- Extra message fields are preserved when placeholder messages are inserted.
 
 **Example:**
 
 ```ruby
 prompt = client.get_prompt("chat-assistant")
-messages = prompt.compile(topic: "Ruby", level: "beginner")
+messages = prompt.compile(
+  topic: "Ruby",
+  level: "beginner",
+  history: [{ role: :user, content: "Explain {{topic}} simply." }]
+)
 # => [
 #   { role: :system, content: "..." },
+#   { role: :user, content: "Explain Ruby simply." },
 #   { role: :user, content: "..." }
 # ]
 ```

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -114,6 +114,36 @@ puts messages
 
 **Note:** Message roles are returned as symbols (`:system`, `:user`, `:assistant`), matching Ruby conventions.
 
+### Message Placeholders
+
+Chat prompts can include Langfuse message placeholders for runtime chat history or few-shot examples:
+
+```ruby
+prompt = client.get_prompt("movie-critic-chat", type: :chat)
+
+messages = prompt.compile(
+  criticlevel: "expert",
+  chat_history: [
+    { role: :user, content: "I like slow cinema." },
+    { role: :assistant, content: "Try contemplative international dramas." }
+  ]
+)
+
+# => [
+#   { role: :system, content: "You are an expert movie critic" },
+#   { role: :user, content: "I like slow cinema." },
+#   { role: :assistant, content: "Try contemplative international dramas." },
+#   { role: :user, content: "What should I watch next?" }
+# ]
+```
+
+Placeholder behavior follows the Langfuse Python SDK:
+
+- Passing an array inserts those messages in place and compiles variables inside them.
+- Passing an empty array skips the placeholder.
+- Omitting the placeholder keeps `{ type: "placeholder", name: "..." }` in the compiled output and logs a warning.
+- Placeholder messages preserve extra fields such as `tool_calls`.
+
 ### Using with LLM Libraries
 
 Direct integration with OpenAI:
@@ -339,6 +369,7 @@ prompt = client.create_prompt(
   name: "support-bot",
   prompt: [
     { role: "system", content: "You are a {{role}} support assistant for {{company}}." },
+    { type: "placeholder", name: "history" },
     { role: "user", content: "{{question}}" }
   ],
   type: :chat,
@@ -347,7 +378,7 @@ prompt = client.create_prompt(
 )
 ```
 
-**Note:** Message roles can use either strings (`"system"`) or symbols (`:system`).
+**Note:** Message roles can use either strings (`"system"`) or symbols (`:system`). Placeholder entries must use `type: "placeholder"` and a `name`.
 
 ### Commit Messages
 

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -119,10 +119,10 @@ puts messages
 Chat prompts can include Langfuse message placeholders for runtime chat history or few-shot examples:
 
 ```ruby
-prompt = client.get_prompt("movie-critic-chat", type: :chat)
+prompt = client.get_prompt("movie-critic-chat")
 
 messages = prompt.compile(
-  criticlevel: "expert",
+  critic_level: "expert",
   chat_history: [
     { role: :user, content: "I like slow cinema." },
     { role: :assistant, content: "Try contemplative international dramas." }

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -137,11 +137,12 @@ messages = prompt.compile(
 # ]
 ```
 
-Placeholder behavior follows the Langfuse Python SDK:
+Placeholder behavior:
 
 - Passing an array inserts those messages in place and compiles variables inside them.
 - Passing an empty array skips the placeholder.
 - Omitting the placeholder keeps `{ type: "placeholder", name: "..." }` in the compiled output and logs a warning.
+- Passing malformed placeholder values raises `ArgumentError` during compile instead of emitting invalid model messages.
 - Placeholder messages preserve extra fields such as `tool_calls`.
 
 ### Using with LLM Libraries

--- a/lib/langfuse/chat_prompt_client.rb
+++ b/lib/langfuse/chat_prompt_client.rb
@@ -189,7 +189,10 @@ module Langfuse
     def warn_unresolved(names)
       return if names.empty?
 
-      warn_msg("Placeholders #{names.inspect} have not been resolved. Pass them as keyword arguments to compile().")
+      unresolved_names = names.uniq.sort
+      message = "Placeholders #{unresolved_names.inspect} have not been resolved. " \
+                "Pass them as keyword arguments to compile()."
+      warn_msg(message)
     end
 
     # @api private

--- a/lib/langfuse/chat_prompt_client.rb
+++ b/lib/langfuse/chat_prompt_client.rb
@@ -20,6 +20,8 @@ module Langfuse
   #   chat_prompt.labels    # => ["production"]
   #
   class ChatPromptClient
+    PLACEHOLDER_TYPE = "placeholder"
+
     # @return [String] Prompt name
     attr_reader :name
 
@@ -76,17 +78,18 @@ module Langfuse
     #   #   { role: :user, content: "Hello Alice, let's discuss Ruby!" }
     #   # ]
     def compile(**kwargs)
-      unresolved_placeholders = []
-      compiled_messages = prompt.flat_map do |message|
-        if placeholder_message?(message)
-          compile_placeholder(message, kwargs, unresolved_placeholders)
+      unresolved = []
+      compiled = []
+      prompt.each do |message|
+        normalized = symbolize_keys(message)
+        if normalized[:type].to_s == PLACEHOLDER_TYPE
+          append_placeholder(normalized, kwargs, compiled, unresolved)
         else
-          [compile_message(message, kwargs)]
+          compiled << compile_message(normalized, kwargs)
         end
       end
-
-      warn_unresolved_placeholders(unresolved_placeholders)
-      compiled_messages
+      warn_unresolved(unresolved)
+      compiled
     end
 
     private
@@ -105,125 +108,90 @@ module Langfuse
 
     # Compile a single role/content message with variable substitution
     #
-    # @param message [Hash] The message with role and content
+    # @param normalized [Hash] Symbolized message hash
     # @param variables [Hash] Variables to substitute
     # @return [Hash] Compiled message with :role and :content as symbols
-    def compile_message(message, variables)
-      normalized = symbolize_keys(message)
-      content = normalized[:content] || ""
-      compiled_content = variables.empty? ? content : PromptRenderer.render(content, variables)
-
-      normalized.except(:type).merge(
+    def compile_message(normalized, variables)
+      normalized.merge(
         role: normalize_role(normalized[:role]),
-        content: compiled_content
+        content: render(normalized[:content] || "", variables)
       )
     end
 
     # @api private
-    def compile_placeholder(message, variables, unresolved_placeholders)
-      placeholder_name = placeholder_name(message)
-      found, value = placeholder_value(variables, placeholder_name)
+    def append_placeholder(message, variables, compiled, unresolved)
+      name = message[:name].to_s
+      found, value = lookup_placeholder(variables, name)
+      return append_unresolved(name, compiled, unresolved) unless found
 
-      unless found
-        unresolved_placeholders << placeholder_name
-        return [placeholder_entry(placeholder_name)]
+      expand_placeholder(name, value, variables, compiled)
+    end
+
+    # @api private
+    def append_unresolved(name, compiled, unresolved)
+      unresolved << name
+      compiled << { type: PLACEHOLDER_TYPE, name: name }
+    end
+
+    # @api private
+    def expand_placeholder(name, value, variables, compiled)
+      return if value.is_a?(Array) && value.empty?
+
+      unless value.is_a?(Array)
+        warn_msg("Placeholder '#{name}' must contain an array of chat messages, got #{value.class}.")
+        compiled << not_given(value.to_s)
+        return
       end
 
-      return [] if value.is_a?(Array) && value.empty?
-      return malformed_placeholder_value(placeholder_name, value) unless value.is_a?(Array)
-
-      value.flat_map do |placeholder_message|
-        compile_placeholder_message(placeholder_name, placeholder_message, value, variables)
-      end
+      value.each { |entry| compiled << placeholder_message(entry, variables, name, value) }
     end
 
     # @api private
-    def compile_placeholder_message(placeholder_name, message, placeholder_value, variables)
-      return malformed_placeholder_message(placeholder_name, placeholder_value) unless message.is_a?(Hash)
-
-      normalized = symbolize_keys(message)
-      content = normalized.fetch(:content, "")
-      compiled_content = variables.empty? ? content : PromptRenderer.render(content, variables)
-
-      [
-        normalized.merge(
-          role: normalize_role(normalized.fetch(:role, "NOT_GIVEN")),
-          content: compiled_content
-        )
-      ]
-    end
-
-    # @api private
-    def malformed_placeholder_value(placeholder_name, value)
-      warn_placeholder("Placeholder '#{placeholder_name}' must contain an array of chat messages, got #{value.class}.")
-      [not_given_message(value.to_s)]
-    end
-
-    # @api private
-    def malformed_placeholder_message(placeholder_name, placeholder_value)
-      warn_placeholder(
-        "Placeholder '#{placeholder_name}' should contain chat message hashes. Appended as string."
-      )
-      [not_given_message(placeholder_value.to_s)]
-    end
-
-    # @api private
-    def placeholder_message?(message)
-      message.is_a?(Hash) && value_for(message, :type).to_s == "placeholder"
-    end
-
-    # @api private
-    def placeholder_name(message)
-      value_for(message, :name).to_s
-    end
-
-    # @api private
-    def placeholder_entry(name)
-      { type: "placeholder", name: name }
-    end
-
-    # @api private
-    def not_given_message(content)
-      { role: :not_given, content: content }
-    end
-
-    # @api private
-    def placeholder_value(variables, name)
-      symbol_name = name.to_sym
+    def lookup_placeholder(variables, name)
+      return [true, variables[name.to_sym]] if variables.key?(name.to_sym)
       return [true, variables[name]] if variables.key?(name)
-      return [true, variables[symbol_name]] if variables.key?(symbol_name)
 
       [false, nil]
     end
 
     # @api private
-    def warn_unresolved_placeholders(names)
-      return if names.empty?
-
-      warn_placeholder(
-        "Placeholders #{names.inspect} have not been resolved. Pass them as keyword arguments to compile()."
+    def placeholder_message(message, variables, name, raw_value)
+      unless message.is_a?(Hash)
+        warn_msg("Placeholder '#{name}' should contain chat message hashes. Appended as string.")
+        return not_given(raw_value.to_s)
+      end
+      normalized = symbolize_keys(message)
+      normalized.merge(
+        role: normalize_role(normalized.fetch(:role, "NOT_GIVEN")),
+        content: render(normalized.fetch(:content, ""), variables)
       )
     end
 
     # @api private
-    def warn_placeholder(message)
-      return unless Langfuse.respond_to?(:configuration)
+    def render(content, variables)
+      variables.empty? ? content : PromptRenderer.render(content, variables)
+    end
 
+    # @api private
+    def not_given(content)
+      { role: :not_given, content: content }
+    end
+
+    # @api private
+    def warn_unresolved(names)
+      return if names.empty?
+
+      warn_msg("Placeholders #{names.inspect} have not been resolved. Pass them as keyword arguments to compile().")
+    end
+
+    # @api private
+    def warn_msg(message)
       Langfuse.configuration.logger.warn("Langfuse: #{message}")
     end
 
     # @api private
     def symbolize_keys(hash)
-      hash.transform_keys do |key|
-        key.to_sym
-      rescue StandardError
-        key
-      end
-    end
-
-    # @api private
-    def value_for(hash, key)
-      hash[key.to_s] || hash[key.to_sym]
+      hash.transform_keys(&:to_sym)
     end
 
     # Normalize role to symbol

--- a/lib/langfuse/chat_prompt_client.rb
+++ b/lib/langfuse/chat_prompt_client.rb
@@ -63,13 +63,14 @@ module Langfuse
     # Compile the chat prompt with variable substitution and message placeholders
     #
     # Returns an array of message hashes with roles and compiled content.
-    # Placeholder entries are resolved from keyword arguments using the
-    # Langfuse Python SDK semantics: arrays are expanded, empty arrays are
-    # skipped, unresolved placeholders stay in the output, and malformed values
-    # degrade to a synthetic message with a warning.
+    # Placeholder entries are resolved from keyword arguments: arrays are
+    # expanded, empty arrays are skipped, unresolved placeholders stay in the
+    # output, and malformed values raise before invalid messages are sent to
+    # an LLM provider.
     #
     # @param kwargs [Hash] Variables and placeholder values to compile
     # @return [Array<Hash>] Array of compiled messages and unresolved placeholders
+    # @raise [ArgumentError] if a placeholder value is malformed
     #
     # @example
     #   chat_prompt.compile(name: "Alice", topic: "Ruby")
@@ -138,12 +139,10 @@ module Langfuse
       return if value.is_a?(Array) && value.empty?
 
       unless value.is_a?(Array)
-        warn_msg("Placeholder '#{name}' must contain an array of chat messages, got #{value.class}.")
-        compiled << not_given(value.to_s)
-        return
+        raise ArgumentError, "Placeholder '#{name}' must contain an array of chat message hashes, got #{value.class}."
       end
 
-      value.each { |entry| compiled << placeholder_message(entry, variables, name, value) }
+      value.each { |entry| compiled << placeholder_message(entry, variables, name) }
     end
 
     # @api private
@@ -155,15 +154,21 @@ module Langfuse
     end
 
     # @api private
-    def placeholder_message(message, variables, name, raw_value)
+    def placeholder_message(message, variables, name)
       unless message.is_a?(Hash)
-        warn_msg("Placeholder '#{name}' should contain chat message hashes. Appended as string.")
-        return not_given(raw_value.to_s)
+        raise ArgumentError,
+              "Placeholder '#{name}' must contain an array of chat message hashes with role and content fields."
       end
+
       normalized = symbolize_keys(message)
+      unless valid_placeholder_message?(normalized)
+        raise ArgumentError,
+              "Placeholder '#{name}' must contain an array of chat message hashes with role and content fields."
+      end
+
       normalized.merge(
-        role: normalize_role(normalized.fetch(:role, "NOT_GIVEN")),
-        content: render(normalized.fetch(:content, ""), variables)
+        role: normalize_role(normalized[:role]),
+        content: render(normalized[:content] || "", variables)
       )
     end
 
@@ -173,8 +178,11 @@ module Langfuse
     end
 
     # @api private
-    def not_given(content)
-      { role: :not_given, content: content }
+    def valid_placeholder_message?(message)
+      message.is_a?(Hash) &&
+        message.key?(:role) &&
+        !message[:role].to_s.empty? &&
+        message.key?(:content)
     end
 
     # @api private

--- a/lib/langfuse/chat_prompt_client.rb
+++ b/lib/langfuse/chat_prompt_client.rb
@@ -112,7 +112,7 @@ module Langfuse
     # @param variables [Hash] Variables to substitute
     # @return [Hash] Compiled message with :role and :content as symbols
     def compile_message(normalized, variables)
-      normalized.merge(
+      normalized.except(:type).merge(
         role: normalize_role(normalized[:role]),
         content: render(normalized[:content] || "", variables)
       )

--- a/lib/langfuse/chat_prompt_client.rb
+++ b/lib/langfuse/chat_prompt_client.rb
@@ -35,7 +35,7 @@ module Langfuse
     # @return [Hash] Prompt configuration
     attr_reader :config
 
-    # @return [Array<Hash>] Array of message hashes with role and content
+    # @return [Array<Hash>] Array of message hashes and placeholder entries
     attr_reader :prompt
 
     # @return [Boolean] Whether this client uses caller-provided fallback content
@@ -58,14 +58,16 @@ module Langfuse
       @is_fallback = is_fallback
     end
 
-    # Compile the chat prompt with variable substitution
+    # Compile the chat prompt with variable substitution and message placeholders
     #
     # Returns an array of message hashes with roles and compiled content.
-    # Each message in the prompt will have its content compiled with the
-    # provided variables using Mustache templating.
+    # Placeholder entries are resolved from keyword arguments using the
+    # Langfuse Python SDK semantics: arrays are expanded, empty arrays are
+    # skipped, unresolved placeholders stay in the output, and malformed values
+    # degrade to a synthetic message with a warning.
     #
-    # @param kwargs [Hash] Variables to substitute in message templates (as keyword arguments)
-    # @return [Array<Hash>] Array of compiled messages with :role and :content keys
+    # @param kwargs [Hash] Variables and placeholder values to compile
+    # @return [Array<Hash>] Array of compiled messages and unresolved placeholders
     #
     # @example
     #   chat_prompt.compile(name: "Alice", topic: "Ruby")
@@ -74,9 +76,17 @@ module Langfuse
     #   #   { role: :user, content: "Hello Alice, let's discuss Ruby!" }
     #   # ]
     def compile(**kwargs)
-      prompt.map do |message|
-        compile_message(message, kwargs)
+      unresolved_placeholders = []
+      compiled_messages = prompt.flat_map do |message|
+        if placeholder_message?(message)
+          compile_placeholder(message, kwargs, unresolved_placeholders)
+        else
+          [compile_message(message, kwargs)]
+        end
       end
+
+      warn_unresolved_placeholders(unresolved_placeholders)
+      compiled_messages
     end
 
     private
@@ -93,19 +103,127 @@ module Langfuse
       raise ArgumentError, "prompt must be an Array" unless prompt_data["prompt"].is_a?(Array)
     end
 
-    # Compile a single message with variable substitution
+    # Compile a single role/content message with variable substitution
     #
     # @param message [Hash] The message with role and content
     # @param variables [Hash] Variables to substitute
     # @return [Hash] Compiled message with :role and :content as symbols
     def compile_message(message, variables)
-      content = message["content"] || ""
+      normalized = symbolize_keys(message)
+      content = normalized[:content] || ""
       compiled_content = variables.empty? ? content : PromptRenderer.render(content, variables)
 
-      {
-        role: normalize_role(message["role"]),
+      normalized.except(:type).merge(
+        role: normalize_role(normalized[:role]),
         content: compiled_content
-      }
+      )
+    end
+
+    # @api private
+    def compile_placeholder(message, variables, unresolved_placeholders)
+      placeholder_name = placeholder_name(message)
+      found, value = placeholder_value(variables, placeholder_name)
+
+      unless found
+        unresolved_placeholders << placeholder_name
+        return [placeholder_entry(placeholder_name)]
+      end
+
+      return [] if value.is_a?(Array) && value.empty?
+      return malformed_placeholder_value(placeholder_name, value) unless value.is_a?(Array)
+
+      value.flat_map do |placeholder_message|
+        compile_placeholder_message(placeholder_name, placeholder_message, value, variables)
+      end
+    end
+
+    # @api private
+    def compile_placeholder_message(placeholder_name, message, placeholder_value, variables)
+      return malformed_placeholder_message(placeholder_name, placeholder_value) unless message.is_a?(Hash)
+
+      normalized = symbolize_keys(message)
+      content = normalized.fetch(:content, "")
+      compiled_content = variables.empty? ? content : PromptRenderer.render(content, variables)
+
+      [
+        normalized.merge(
+          role: normalize_role(normalized.fetch(:role, "NOT_GIVEN")),
+          content: compiled_content
+        )
+      ]
+    end
+
+    # @api private
+    def malformed_placeholder_value(placeholder_name, value)
+      warn_placeholder("Placeholder '#{placeholder_name}' must contain an array of chat messages, got #{value.class}.")
+      [not_given_message(value.to_s)]
+    end
+
+    # @api private
+    def malformed_placeholder_message(placeholder_name, placeholder_value)
+      warn_placeholder(
+        "Placeholder '#{placeholder_name}' should contain chat message hashes. Appended as string."
+      )
+      [not_given_message(placeholder_value.to_s)]
+    end
+
+    # @api private
+    def placeholder_message?(message)
+      message.is_a?(Hash) && value_for(message, :type).to_s == "placeholder"
+    end
+
+    # @api private
+    def placeholder_name(message)
+      value_for(message, :name).to_s
+    end
+
+    # @api private
+    def placeholder_entry(name)
+      { type: "placeholder", name: name }
+    end
+
+    # @api private
+    def not_given_message(content)
+      { role: :not_given, content: content }
+    end
+
+    # @api private
+    def placeholder_value(variables, name)
+      symbol_name = name.to_sym
+      return [true, variables[name]] if variables.key?(name)
+      return [true, variables[symbol_name]] if variables.key?(symbol_name)
+
+      [false, nil]
+    end
+
+    # @api private
+    def warn_unresolved_placeholders(names)
+      return if names.empty?
+
+      warn_placeholder(
+        "Placeholders #{names.inspect} have not been resolved. Pass them as keyword arguments to compile()."
+      )
+    end
+
+    # @api private
+    def warn_placeholder(message)
+      return unless Langfuse.respond_to?(:configuration)
+
+      Langfuse.configuration.logger.warn("Langfuse: #{message}")
+    end
+
+    # @api private
+    def symbolize_keys(hash)
+      hash.transform_keys do |key|
+        key.to_sym
+      rescue StandardError
+        key
+      end
+    end
+
+    # @api private
+    def value_for(hash, key)
+      hash[key.to_s] || hash[key.to_sym]
     end
 
     # Normalize role to symbol

--- a/lib/langfuse/client.rb
+++ b/lib/langfuse/client.rb
@@ -867,26 +867,17 @@ module Langfuse
 
       # Normalize chat messages to use string keys
       prompt.map do |message|
-        normalized = normalize_chat_item_keys(message)
-        next placeholder_prompt_content(normalized) if normalized["type"] == "placeholder"
+        normalized = message.transform_keys(&:to_s)
+        next placeholder_prompt_content(normalized) if normalized["type"] == ChatPromptClient::PLACEHOLDER_TYPE
 
         normalize_chat_message_content(normalized)
       end
     end
 
     # @api private
-    def normalize_chat_item_keys(message)
-      message.transform_keys do |key|
-        key.to_s
-      rescue StandardError
-        key
-      end
-    end
-
-    # @api private
     def placeholder_prompt_content(message)
       {
-        "type" => "placeholder",
+        "type" => ChatPromptClient::PLACEHOLDER_TYPE,
         "name" => message["name"].to_s
       }
     end

--- a/lib/langfuse/client.rb
+++ b/lib/langfuse/client.rb
@@ -856,7 +856,8 @@ module Langfuse
 
     # Normalize prompt content for API request
     #
-    # Converts Ruby symbol keys to string keys for chat messages
+    # Converts Ruby symbol keys to string keys for chat messages and preserves
+    # Langfuse message placeholder entries.
     #
     # @param prompt [String, Array] The prompt content
     # @param type [Symbol] The prompt type
@@ -866,17 +867,36 @@ module Langfuse
 
       # Normalize chat messages to use string keys
       prompt.map do |message|
-        # Convert all keys to symbols first, then extract
-        normalized = message.transform_keys do |k|
-          k.to_sym
-        rescue StandardError
-          k
-        end
-        {
-          "role" => normalized[:role]&.to_s,
-          "content" => normalized[:content]
-        }
+        normalized = normalize_chat_item_keys(message)
+        next placeholder_prompt_content(normalized) if normalized["type"] == "placeholder"
+
+        normalize_chat_message_content(normalized)
       end
+    end
+
+    # @api private
+    def normalize_chat_item_keys(message)
+      message.transform_keys do |key|
+        key.to_s
+      rescue StandardError
+        key
+      end
+    end
+
+    # @api private
+    def placeholder_prompt_content(message)
+      {
+        "type" => "placeholder",
+        "name" => message["name"].to_s
+      }
+    end
+
+    # @api private
+    def normalize_chat_message_content(message)
+      message.merge(
+        "role" => message["role"]&.to_s,
+        "content" => message["content"]
+      )
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/spec/langfuse/chat_prompt_client_spec.rb
+++ b/spec/langfuse/chat_prompt_client_spec.rb
@@ -289,6 +289,18 @@ RSpec.describe Langfuse::ChatPromptClient do
                                { role: :user, content: "Help me with billing." }
                              ])
       end
+
+      it "strips message type metadata from compiled normal messages" do
+        data = prompt_data.merge(
+          "prompt" => [
+            { "type" => "message", "role" => "user", "content" => "Hi {{name}}" }
+          ]
+        )
+
+        result = described_class.new(data).compile(name: "Ada")
+
+        expect(result).to eq([{ role: :user, content: "Hi Ada" }])
+      end
     end
 
     context "with complex templates" do

--- a/spec/langfuse/chat_prompt_client_spec.rb
+++ b/spec/langfuse/chat_prompt_client_spec.rb
@@ -205,6 +205,92 @@ RSpec.describe Langfuse::ChatPromptClient do
       end
     end
 
+    context "with message placeholders" do
+      let(:placeholder_prompt_data) do
+        prompt_data.merge(
+          "prompt" => [
+            { "role" => "system", "content" => "You are a {{role}} assistant." },
+            { "type" => "placeholder", "name" => "history" },
+            { "role" => "user", "content" => "Help me with {{task}}." }
+          ]
+        )
+      end
+
+      let(:client) { described_class.new(placeholder_prompt_data) }
+
+      it "inserts placeholder messages and compiles their content" do
+        result = client.compile(
+          role: "helpful",
+          task: "billing",
+          history: [
+            { role: :user, content: "Show {{task}} context" },
+            { role: :assistant, content: "Prior answer", tool_calls: [{ id: "call_1" }] }
+          ]
+        )
+
+        expect(result).to eq([
+                               { role: :system, content: "You are a helpful assistant." },
+                               { role: :user, content: "Show billing context" },
+                               { role: :assistant, content: "Prior answer", tool_calls: [{ id: "call_1" }] },
+                               { role: :user, content: "Help me with billing." }
+                             ])
+      end
+
+      it "skips placeholders resolved to empty arrays" do
+        result = client.compile(role: "helpful", task: "billing", history: [])
+
+        expect(result).to eq([
+                               { role: :system, content: "You are a helpful assistant." },
+                               { role: :user, content: "Help me with billing." }
+                             ])
+      end
+
+      it "keeps unresolved placeholders and warns" do
+        expect(Langfuse.configuration.logger).to receive(:warn)
+          .with(/Placeholders \["history"\] have not been resolved/)
+
+        result = client.compile(role: "helpful", task: "billing")
+
+        expect(result).to eq([
+                               { role: :system, content: "You are a helpful assistant." },
+                               { type: "placeholder", name: "history" },
+                               { role: :user, content: "Help me with billing." }
+                             ])
+      end
+
+      it "degrades non-array placeholder values to a synthetic message and warns" do
+        expect(Langfuse.configuration.logger).to receive(:warn)
+          .with(/Placeholder 'history' must contain an array of chat messages/)
+
+        result = client.compile(role: "helpful", task: "billing", history: "not a list")
+
+        expect(result).to eq([
+                               { role: :system, content: "You are a helpful assistant." },
+                               { role: :not_given, content: "not a list" },
+                               { role: :user, content: "Help me with billing." }
+                             ])
+      end
+
+      it "preserves valid messages and degrades malformed array entries" do
+        placeholder_value = [
+          "invalid message",
+          { "role" => "user", "content" => "valid {{task}} message" }
+        ]
+
+        expect(Langfuse.configuration.logger).to receive(:warn)
+          .with(/Placeholder 'history' should contain chat message hashes/)
+
+        result = client.compile(role: "helpful", task: "billing", history: placeholder_value)
+
+        expect(result).to eq([
+                               { role: :system, content: "You are a helpful assistant." },
+                               { role: :not_given, content: placeholder_value.to_s },
+                               { role: :user, content: "valid billing message" },
+                               { role: :user, content: "Help me with billing." }
+                             ])
+      end
+    end
+
     context "with complex templates" do
       it "handles nested object properties" do
         data = prompt_data.dup

--- a/spec/langfuse/chat_prompt_client_spec.rb
+++ b/spec/langfuse/chat_prompt_client_spec.rb
@@ -258,36 +258,36 @@ RSpec.describe Langfuse::ChatPromptClient do
                              ])
       end
 
-      it "degrades non-array placeholder values to a synthetic message and warns" do
-        expect(Langfuse.configuration.logger).to receive(:warn)
-          .with(/Placeholder 'history' must contain an array of chat messages/)
-
-        result = client.compile(role: "helpful", task: "billing", history: "not a list")
-
-        expect(result).to eq([
-                               { role: :system, content: "You are a helpful assistant." },
-                               { role: :not_given, content: "not a list" },
-                               { role: :user, content: "Help me with billing." }
-                             ])
+      it "raises for non-array placeholder values" do
+        expect do
+          client.compile(role: "helpful", task: "billing", history: "not a list")
+        end.to raise_error(
+          ArgumentError,
+          "Placeholder 'history' must contain an array of chat message hashes, got String."
+        )
       end
 
-      it "preserves valid messages and degrades malformed array entries" do
+      it "raises for malformed placeholder array entries" do
         placeholder_value = [
           "invalid message",
           { "role" => "user", "content" => "valid {{task}} message" }
         ]
 
-        expect(Langfuse.configuration.logger).to receive(:warn)
-          .with(/Placeholder 'history' should contain chat message hashes/)
+        expect do
+          client.compile(role: "helpful", task: "billing", history: placeholder_value)
+        end.to raise_error(
+          ArgumentError,
+          "Placeholder 'history' must contain an array of chat message hashes with role and content fields."
+        )
+      end
 
-        result = client.compile(role: "helpful", task: "billing", history: placeholder_value)
-
-        expect(result).to eq([
-                               { role: :system, content: "You are a helpful assistant." },
-                               { role: :not_given, content: placeholder_value.to_s },
-                               { role: :user, content: "valid billing message" },
-                               { role: :user, content: "Help me with billing." }
-                             ])
+      it "raises when placeholder messages are missing role or content" do
+        expect do
+          client.compile(role: "helpful", task: "billing", history: [{ role: :user }])
+        end.to raise_error(
+          ArgumentError,
+          "Placeholder 'history' must contain an array of chat message hashes with role and content fields."
+        )
       end
 
       it "strips message type metadata from compiled normal messages" do

--- a/spec/langfuse/chat_prompt_client_spec.rb
+++ b/spec/langfuse/chat_prompt_client_spec.rb
@@ -258,6 +258,22 @@ RSpec.describe Langfuse::ChatPromptClient do
                              ])
       end
 
+      it "deduplicates unresolved placeholder names in warnings" do
+        data = placeholder_prompt_data.merge(
+          "prompt" => [
+            { "type" => "placeholder", "name" => "history" },
+            { "type" => "placeholder", "name" => "examples" },
+            { "type" => "placeholder", "name" => "history" }
+          ]
+        )
+        client = described_class.new(data)
+
+        expect(Langfuse.configuration.logger).to receive(:warn)
+          .with(/Placeholders \["examples", "history"\] have not been resolved/)
+
+        client.compile
+      end
+
       it "raises for non-array placeholder values" do
         expect do
           client.compile(role: "helpful", task: "billing", history: "not a list")

--- a/spec/langfuse/client_spec.rb
+++ b/spec/langfuse/client_spec.rb
@@ -290,6 +290,25 @@ RSpec.describe Langfuse::Client do
         expect(result.prompt).to be_an(Array)
         expect(result.is_fallback).to be(false)
       end
+
+      it "preserves placeholder entries returned by the API" do
+        placeholder_response = chat_prompt_response.merge(
+          "prompt" => chat_prompt_response["prompt"].dup.insert(
+            1,
+            { "type" => "placeholder", "name" => "history" }
+          )
+        )
+        stub_request(:get, "#{base_url}/api/public/v2/prompts/chat-assistant")
+          .to_return(
+            status: 200,
+            body: placeholder_response.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        result = client.get_prompt("chat-assistant")
+
+        expect(result.prompt[1]).to eq({ "type" => "placeholder", "name" => "history" })
+      end
     end
 
     context "with unknown prompt type" do
@@ -1075,6 +1094,50 @@ RSpec.describe Langfuse::Client do
           a_request(:post, "#{base_url}/api/public/v2/prompts")
             .with(body: hash_including(
               "prompt" => [{ "role" => "system", "content" => "You are helpful" }]
+            ))
+        ).to have_been_made.once
+      end
+
+      it "normalizes placeholders without dropping their type and name" do
+        client.create_prompt(
+          name: "assistant",
+          prompt: [
+            { role: :system, content: "You are helpful" },
+            { type: "placeholder", name: :history },
+            { role: :user, content: "Hi" }
+          ],
+          type: :chat
+        )
+
+        expect(
+          a_request(:post, "#{base_url}/api/public/v2/prompts")
+            .with(body: hash_including(
+              "prompt" => [
+                { "role" => "system", "content" => "You are helpful" },
+                { "type" => "placeholder", "name" => "history" },
+                { "role" => "user", "content" => "Hi" }
+              ]
+            ))
+        ).to have_been_made.once
+      end
+
+      it "preserves extra message fields during normalization" do
+        client.create_prompt(
+          name: "assistant",
+          prompt: [{ role: :assistant, content: "Prior answer", tool_calls: [{ id: "call_1" }] }],
+          type: :chat
+        )
+
+        expect(
+          a_request(:post, "#{base_url}/api/public/v2/prompts")
+            .with(body: hash_including(
+              "prompt" => [
+                {
+                  "role" => "assistant",
+                  "content" => "Prior answer",
+                  "tool_calls" => [{ "id" => "call_1" }]
+                }
+              ]
             ))
         ).to have_been_made.once
       end


### PR DESCRIPTION
## Summary

- preserve Langfuse chat prompt placeholder entries during create/fetch flows
- compile placeholders with Python-aligned behavior: expand arrays, skip empty arrays, keep unresolved placeholders with warnings, and degrade malformed values predictably
- preserve extra fields on inserted placeholder messages, including tool-call history
- document chat prompt placeholder behavior and add changelog coverage

## Validation

- `RBENV_VERSION=3.2.0 rbenv exec bundle _2.4.7_ exec rspec`
- `RBENV_VERSION=3.2.0 rbenv exec bundle _2.4.7_ exec rubocop`
- `npx -y langfuse-cli api __schema`
- live Langfuse smoke: created/fetched `ruby-placeholder-parity-20260428015139-3e3043`, compiled resolved/empty/unresolved/malformed placeholders, and confirmed CLI readback preserved `{ type: "placeholder", name: "history" }`
