### PR TITLE
feat(prompts): expose prompt metadata

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -434,6 +434,9 @@ Returned by `get_prompt` for text prompts.
 | `tags`    | Array<String> | Tags                   |
 | `config`  | Hash          | Prompt config hash returned by Langfuse |
 | `prompt`  | String        | Raw template           |
+| `type`    | String        | Prompt type (`"text"` or `"chat"`) |
+| `commit_message` | String, nil | Commit message for the prompt version |
+| `resolution_graph` | Hash, nil | Dependency resolution graph for composed prompts when returned by Langfuse |
 | `is_fallback` | Boolean  | Whether the client uses caller-provided fallback content |
 
 **Methods:**

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -434,7 +434,7 @@ Returned by `get_prompt` for text prompts.
 | `tags`    | Array<String> | Tags                   |
 | `config`  | Hash          | Prompt config hash returned by Langfuse |
 | `prompt`  | String        | Raw template           |
-| `type`    | String        | Prompt type (`"text"` or `"chat"`) |
+| `type`    | String        | Prompt type (`"text"`) |
 | `commit_message` | String, nil | Commit message for the prompt version |
 | `resolution_graph` | Hash, nil | Dependency resolution graph for composed prompts when returned by Langfuse |
 | `is_fallback` | Boolean  | Whether the client uses caller-provided fallback content |
@@ -460,7 +460,7 @@ message = prompt.compile(name: "Alice", time: "morning")
 
 Returned by `get_prompt` for chat prompts.
 
-**Properties:** Same as `TextPromptClient`
+**Properties:** Same as `TextPromptClient`, except `prompt` is an `Array<Hash>` and `type` is `"chat"`.
 
 **Methods:**
 

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -44,6 +44,9 @@ prompt.labels     # => ["production"]
 prompt.tags       # => ["marketing", "seo"]
 prompt.config     # => { "temperature" => 0.7, "model" => "gpt-4" }
 prompt.prompt     # => "Write a {{tone}} product description for {{product_name}}..."
+prompt.type       # => "text"
+prompt.commit_message  # => "Improve product tone"
+prompt.resolution_graph # => nil
 prompt.is_fallback # => false
 ```
 

--- a/lib/langfuse/chat_prompt_client.rb
+++ b/lib/langfuse/chat_prompt_client.rb
@@ -40,9 +40,6 @@ module Langfuse
     # @return [Array<Hash>] Array of message hashes and placeholder entries
     attr_reader :prompt
 
-    # @return [String] Prompt type
-    attr_reader :type
-
     # @return [String, nil] Optional commit message for this prompt version
     attr_reader :commit_message
 
@@ -66,10 +63,14 @@ module Langfuse
       @labels = prompt_data["labels"] || []
       @tags = prompt_data["tags"] || []
       @config = prompt_data["config"] || {}
-      @type = prompt_data["type"] || "chat"
-      @commit_message = prompt_data["commitMessage"] || prompt_data["commit_message"]
-      @resolution_graph = prompt_data["resolutionGraph"] || prompt_data["resolution_graph"]
+      @commit_message = prompt_data["commitMessage"]
+      @resolution_graph = prompt_data["resolutionGraph"]
       @is_fallback = is_fallback
+    end
+
+    # @return [String] Prompt type ("chat")
+    def type
+      "chat"
     end
 
     # Compile the chat prompt with variable substitution and message placeholders

--- a/lib/langfuse/chat_prompt_client.rb
+++ b/lib/langfuse/chat_prompt_client.rb
@@ -40,6 +40,15 @@ module Langfuse
     # @return [Array<Hash>] Array of message hashes and placeholder entries
     attr_reader :prompt
 
+    # @return [String] Prompt type
+    attr_reader :type
+
+    # @return [String, nil] Optional commit message for this prompt version
+    attr_reader :commit_message
+
+    # @return [Hash, nil] Optional dependency resolution graph for composed prompts
+    attr_reader :resolution_graph
+
     # @return [Boolean] Whether this client uses caller-provided fallback content
     attr_reader :is_fallback
 
@@ -57,6 +66,9 @@ module Langfuse
       @labels = prompt_data["labels"] || []
       @tags = prompt_data["tags"] || []
       @config = prompt_data["config"] || {}
+      @type = prompt_data["type"] || "chat"
+      @commit_message = prompt_data["commitMessage"] || prompt_data["commit_message"]
+      @resolution_graph = prompt_data["resolutionGraph"] || prompt_data["resolution_graph"]
       @is_fallback = is_fallback
     end
 

--- a/lib/langfuse/text_prompt_client.rb
+++ b/lib/langfuse/text_prompt_client.rb
@@ -38,9 +38,6 @@ module Langfuse
     # @return [String] Raw prompt template string
     attr_reader :prompt
 
-    # @return [String] Prompt type
-    attr_reader :type
-
     # @return [String, nil] Optional commit message for this prompt version
     attr_reader :commit_message
 
@@ -64,10 +61,14 @@ module Langfuse
       @labels = prompt_data["labels"] || []
       @tags = prompt_data["tags"] || []
       @config = prompt_data["config"] || {}
-      @type = prompt_data["type"] || "text"
-      @commit_message = prompt_data["commitMessage"] || prompt_data["commit_message"]
-      @resolution_graph = prompt_data["resolutionGraph"] || prompt_data["resolution_graph"]
+      @commit_message = prompt_data["commitMessage"]
+      @resolution_graph = prompt_data["resolutionGraph"]
       @is_fallback = is_fallback
+    end
+
+    # @return [String] Prompt type ("text")
+    def type
+      "text"
     end
 
     # Compile the prompt with variable substitution

--- a/lib/langfuse/text_prompt_client.rb
+++ b/lib/langfuse/text_prompt_client.rb
@@ -38,6 +38,15 @@ module Langfuse
     # @return [String] Raw prompt template string
     attr_reader :prompt
 
+    # @return [String] Prompt type
+    attr_reader :type
+
+    # @return [String, nil] Optional commit message for this prompt version
+    attr_reader :commit_message
+
+    # @return [Hash, nil] Optional dependency resolution graph for composed prompts
+    attr_reader :resolution_graph
+
     # @return [Boolean] Whether this client uses caller-provided fallback content
     attr_reader :is_fallback
 
@@ -55,6 +64,9 @@ module Langfuse
       @labels = prompt_data["labels"] || []
       @tags = prompt_data["tags"] || []
       @config = prompt_data["config"] || {}
+      @type = prompt_data["type"] || "text"
+      @commit_message = prompt_data["commitMessage"] || prompt_data["commit_message"]
+      @resolution_graph = prompt_data["resolutionGraph"] || prompt_data["resolution_graph"]
       @is_fallback = is_fallback
     end
 

--- a/spec/langfuse/chat_prompt_client_spec.rb
+++ b/spec/langfuse/chat_prompt_client_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe Langfuse::ChatPromptClient do
       "type" => "chat",
       "labels" => %w[production support],
       "tags" => %w[customer-facing critical],
-      "config" => { "temperature" => 0.7, "max_tokens" => 500 }
+      "config" => { "temperature" => 0.7, "max_tokens" => 500 },
+      "commitMessage" => "Tune assistant tone",
+      "resolutionGraph" => { "nodes" => [{ "name" => "shared-chat-rules" }] }
     }
   end
 
@@ -69,6 +71,34 @@ RSpec.describe Langfuse::ChatPromptClient do
       expect(client.config).to eq({ "temperature" => 0.7, "max_tokens" => 500 })
     end
 
+    it "sets the type" do
+      client = described_class.new(prompt_data)
+      expect(client.type).to eq("chat")
+    end
+
+    it "sets the commit message" do
+      client = described_class.new(prompt_data)
+      expect(client.commit_message).to eq("Tune assistant tone")
+    end
+
+    it "sets the resolution graph" do
+      client = described_class.new(prompt_data)
+      expect(client.resolution_graph).to eq({ "nodes" => [{ "name" => "shared-chat-rules" }] })
+    end
+
+    it "accepts Ruby-style metadata keys" do
+      data = prompt_data.merge(
+        "commitMessage" => nil,
+        "resolutionGraph" => nil,
+        "commit_message" => "Ruby key",
+        "resolution_graph" => { "nodes" => [] }
+      )
+      client = described_class.new(data)
+
+      expect(client.commit_message).to eq("Ruby key")
+      expect(client.resolution_graph).to eq({ "nodes" => [] })
+    end
+
     it "defaults labels to empty array when not provided" do
       data = prompt_data.dup.tap { |d| d.delete("labels") }
       client = described_class.new(data)
@@ -85,6 +115,19 @@ RSpec.describe Langfuse::ChatPromptClient do
       data = prompt_data.dup.tap { |d| d.delete("config") }
       client = described_class.new(data)
       expect(client.config).to eq({})
+    end
+
+    it "defaults optional metadata when not provided" do
+      data = prompt_data.dup.tap do |d|
+        d.delete("type")
+        d.delete("commitMessage")
+        d.delete("resolutionGraph")
+      end
+      client = described_class.new(data)
+
+      expect(client.type).to eq("chat")
+      expect(client.commit_message).to be_nil
+      expect(client.resolution_graph).to be_nil
     end
 
     context "with invalid prompt data" do

--- a/spec/langfuse/chat_prompt_client_spec.rb
+++ b/spec/langfuse/chat_prompt_client_spec.rb
@@ -86,19 +86,6 @@ RSpec.describe Langfuse::ChatPromptClient do
       expect(client.resolution_graph).to eq({ "nodes" => [{ "name" => "shared-chat-rules" }] })
     end
 
-    it "accepts Ruby-style metadata keys" do
-      data = prompt_data.merge(
-        "commitMessage" => nil,
-        "resolutionGraph" => nil,
-        "commit_message" => "Ruby key",
-        "resolution_graph" => { "nodes" => [] }
-      )
-      client = described_class.new(data)
-
-      expect(client.commit_message).to eq("Ruby key")
-      expect(client.resolution_graph).to eq({ "nodes" => [] })
-    end
-
     it "defaults labels to empty array when not provided" do
       data = prompt_data.dup.tap { |d| d.delete("labels") }
       client = described_class.new(data)
@@ -119,13 +106,11 @@ RSpec.describe Langfuse::ChatPromptClient do
 
     it "defaults optional metadata when not provided" do
       data = prompt_data.dup.tap do |d|
-        d.delete("type")
         d.delete("commitMessage")
         d.delete("resolutionGraph")
       end
       client = described_class.new(data)
 
-      expect(client.type).to eq("chat")
       expect(client.commit_message).to be_nil
       expect(client.resolution_graph).to be_nil
     end

--- a/spec/langfuse/client_spec.rb
+++ b/spec/langfuse/client_spec.rb
@@ -225,7 +225,9 @@ RSpec.describe Langfuse::Client do
           "prompt" => "Hello {{name}}!",
           "labels" => ["production"],
           "tags" => ["greetings"],
-          "config" => {}
+          "config" => {},
+          "commitMessage" => "Initial greeting",
+          "resolutionGraph" => { "nodes" => [{ "name" => "shared-greeting" }] }
         }
       end
 
@@ -248,6 +250,9 @@ RSpec.describe Langfuse::Client do
         expect(result.name).to eq("greeting")
         expect(result.version).to eq(1)
         expect(result.prompt).to eq("Hello {{name}}!")
+        expect(result.type).to eq("text")
+        expect(result.commit_message).to eq("Initial greeting")
+        expect(result.resolution_graph).to eq({ "nodes" => [{ "name" => "shared-greeting" }] })
         expect(result.is_fallback).to be(false)
       end
     end
@@ -265,7 +270,9 @@ RSpec.describe Langfuse::Client do
           ],
           "labels" => ["production"],
           "tags" => ["chat"],
-          "config" => {}
+          "config" => {},
+          "commitMessage" => "Initial assistant",
+          "resolutionGraph" => { "nodes" => [{ "name" => "shared-assistant" }] }
         }
       end
 
@@ -288,6 +295,9 @@ RSpec.describe Langfuse::Client do
         expect(result.name).to eq("chat-assistant")
         expect(result.version).to eq(2)
         expect(result.prompt).to be_an(Array)
+        expect(result.type).to eq("chat")
+        expect(result.commit_message).to eq("Initial assistant")
+        expect(result.resolution_graph).to eq({ "nodes" => [{ "name" => "shared-assistant" }] })
         expect(result.is_fallback).to be(false)
       end
 

--- a/spec/langfuse/text_prompt_client_spec.rb
+++ b/spec/langfuse/text_prompt_client_spec.rb
@@ -77,19 +77,6 @@ RSpec.describe Langfuse::TextPromptClient do
       expect(client.resolution_graph).to eq({ "nodes" => [{ "name" => "shared-system" }] })
     end
 
-    it "accepts Ruby-style metadata keys" do
-      data = prompt_data.merge(
-        "commitMessage" => nil,
-        "resolutionGraph" => nil,
-        "commit_message" => "Ruby key",
-        "resolution_graph" => { "nodes" => [] }
-      )
-      client = described_class.new(data)
-
-      expect(client.commit_message).to eq("Ruby key")
-      expect(client.resolution_graph).to eq({ "nodes" => [] })
-    end
-
     it "defaults labels to empty array when not provided" do
       data = prompt_data.dup.tap { |d| d.delete("labels") }
       client = described_class.new(data)
@@ -110,13 +97,11 @@ RSpec.describe Langfuse::TextPromptClient do
 
     it "defaults optional metadata when not provided" do
       data = prompt_data.dup.tap do |d|
-        d.delete("type")
         d.delete("commitMessage")
         d.delete("resolutionGraph")
       end
       client = described_class.new(data)
 
-      expect(client.type).to eq("text")
       expect(client.commit_message).to be_nil
       expect(client.resolution_graph).to be_nil
     end

--- a/spec/langfuse/text_prompt_client_spec.rb
+++ b/spec/langfuse/text_prompt_client_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe Langfuse::TextPromptClient do
       "type" => "text",
       "labels" => ["production"],
       "tags" => ["customer-facing"],
-      "config" => { "temperature" => 0.7 }
+      "config" => { "temperature" => 0.7 },
+      "commitMessage" => "Initial version",
+      "resolutionGraph" => { "nodes" => [{ "name" => "shared-system" }] }
     }
   end
 
@@ -60,6 +62,34 @@ RSpec.describe Langfuse::TextPromptClient do
       expect(client.config).to eq({ "temperature" => 0.7 })
     end
 
+    it "sets the type" do
+      client = described_class.new(prompt_data)
+      expect(client.type).to eq("text")
+    end
+
+    it "sets the commit message" do
+      client = described_class.new(prompt_data)
+      expect(client.commit_message).to eq("Initial version")
+    end
+
+    it "sets the resolution graph" do
+      client = described_class.new(prompt_data)
+      expect(client.resolution_graph).to eq({ "nodes" => [{ "name" => "shared-system" }] })
+    end
+
+    it "accepts Ruby-style metadata keys" do
+      data = prompt_data.merge(
+        "commitMessage" => nil,
+        "resolutionGraph" => nil,
+        "commit_message" => "Ruby key",
+        "resolution_graph" => { "nodes" => [] }
+      )
+      client = described_class.new(data)
+
+      expect(client.commit_message).to eq("Ruby key")
+      expect(client.resolution_graph).to eq({ "nodes" => [] })
+    end
+
     it "defaults labels to empty array when not provided" do
       data = prompt_data.dup.tap { |d| d.delete("labels") }
       client = described_class.new(data)
@@ -76,6 +106,19 @@ RSpec.describe Langfuse::TextPromptClient do
       data = prompt_data.dup.tap { |d| d.delete("config") }
       client = described_class.new(data)
       expect(client.config).to eq({})
+    end
+
+    it "defaults optional metadata when not provided" do
+      data = prompt_data.dup.tap do |d|
+        d.delete("type")
+        d.delete("commitMessage")
+        d.delete("resolutionGraph")
+      end
+      client = described_class.new(data)
+
+      expect(client.type).to eq("text")
+      expect(client.commit_message).to be_nil
+      expect(client.resolution_graph).to be_nil
     end
 
     context "with invalid prompt data" do


### PR DESCRIPTION
#### `TL;DR`
Expose prompt client metadata for prompt type, commit message, and dependency resolution graph.

#### `Why`
Ruby prompt clients were dropping API metadata that sibling SDKs preserve on prompt models/clients. Downstream integrations need the full prompt object surface without adding a manager abstraction.

#### `Checklist`
- [x] Has label
- [ ] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)

#### `Summary`
- Add `type`, `commit_message`, and `resolution_graph` readers to text and chat prompt clients.
- Preserve defaults for older prompt payloads and fallback prompt clients.
- Document the expanded prompt-client metadata surface.

#### `Verification`
- `rbenv exec bundle exec rspec`
- `rbenv exec bundle exec rubocop`
- Live Langfuse CLI/Ruby smoke: created a composed prompt, fetched it through the local SDK, verified `type`, `commit_message`, `resolution_graph`, compiled resolved content, then deleted the temporary prompts and confirmed cleanup through the CLI.
