### PR TITLE
feat(tracing): add metrics_reporter config option to surface BSP events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `ScoreClient#create!`, `Client#create_score!`, and `Langfuse.create_score!` create scores through the synchronous Scores API, return the created score ID, and raise API errors. The existing `create` methods retain fire-and-forget ingestion batching.
 - `Langfuse.configured?` checks locally whether the global client can be constructed without accessing the network.
+- `Config#metrics_reporter` forwards OpenTelemetry batch span processor metrics to an application-owned reporter without allowing reporter failures to interrupt tracing.
 
 ### Changed
 - Client construction now rejects invalid `batch_size` and `flush_interval` values before score batching can fail later.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -59,6 +59,7 @@ Block receives a `Langfuse::Config` object with these properties:
 | `should_export_span`           | `#call` | No       | `nil`                          | Span export filter callback        |
 | `mask`                         | `#call` | No       | `nil`                          | Mask callable for input/output/metadata (receives `data:` keyword) |
 | `mask_otel_spans`              | `#call` | No       | `nil`                          | Export-stage span masking hook (receives `params:` keyword; see [CONFIGURATION.md](CONFIGURATION.md#mask_otel_spans)) |
+| `metrics_reporter`             | Object  | No       | `nil`                          | Best-effort OpenTelemetry batch processor metrics reporter; see [CONFIGURATION.md](CONFIGURATION.md#metrics_reporter) |
 
 **Example:**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -312,6 +312,69 @@ config.tracing_async = true
 
 **Current Behavior:** Uses OpenTelemetry `BatchSpanProcessor` in both modes. Async mode uses `flush_interval` for scheduled export; sync mode uses a 60-second schedule delay and is usually paired with explicit `force_flush` for deterministic delivery timing.
 
+#### `metrics_reporter`
+
+- **Type:** Object responding to `add_to_counter`, `record_value`, and `observe_value`, or `nil`
+- **Default:** `nil` (uses OpenTelemetry's no-op reporter)
+- **Description:** Receives operational metrics emitted by OpenTelemetry's `BatchSpanProcessor`
+
+The reporter uses the complete
+[OpenTelemetry metrics reporter interface](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/sdk/lib/opentelemetry/sdk/trace/export/metrics_reporter.rb):
+
+```ruby
+add_to_counter(metric, increment: 1, labels: {})
+record_value(metric, value:, labels: {})
+observe_value(metric, value:, labels: {})
+```
+
+Metric names and labels belong to the installed OpenTelemetry SDK. Langfuse forwards
+them without modification and does not guarantee that they remain stable across
+OpenTelemetry releases. Reporting is best effort. A reporter exception produces one
+warning and does not interrupt span completion or export.
+
+The reporter can run on application threads and the OpenTelemetry export thread. It
+must be thread-safe, fast, and nonblocking. Do not perform HTTP requests or create
+spans from reporter methods. The application owns the reporter lifecycle.
+
+This adapter sends the metrics to Datadog through an existing `Datadog::Statsd`
+instance without adding a Datadog dependency to Langfuse:
+
+```ruby
+class DogStatsdMetricsReporter
+  def initialize(statsd)
+    @statsd = statsd
+  end
+
+  def add_to_counter(metric, increment: 1, labels: {})
+    @statsd.increment(metric, by: increment, tags: tags(labels))
+  end
+
+  def record_value(metric, value:, labels: {})
+    @statsd.distribution(metric, value, tags: tags(labels))
+  end
+
+  def observe_value(metric, value:, labels: {})
+    @statsd.gauge(metric, value, tags: tags(labels))
+  end
+
+  private
+
+  def tags(labels)
+    labels.compact.map { |key, value| "#{key}:#{value}" }
+  end
+end
+
+statsd = Datadog::Statsd.new("127.0.0.1", 8125)
+
+Langfuse.configure do |config|
+  config.metrics_reporter = DogStatsdMetricsReporter.new(statsd)
+end
+```
+
+Use one shared DogStatsD client. At application shutdown, call `Langfuse.shutdown`
+before `statsd.close` so the final batch processor metrics can leave the DogStatsD
+client's buffer.
+
 #### `job_queue` ⚠️ Experimental
 
 - **Type:** Symbol
@@ -495,6 +558,7 @@ After the first successful tracing initialization, these settings require `Langf
 - `release`
 - `sample_rate`
 - `should_export_span`
+- `metrics_reporter`
 - `tracing_async`
 - `batch_size`
 - `flush_interval`
@@ -694,6 +758,7 @@ Tracing reuses the credential, batching, sampling, and logger rules. It also val
 - `should_export_span` must respond to `#call` (if set)
 - `mask` must respond to `#call` (if set)
 - `mask_otel_spans` must respond to `#call` (if set)
+- `metrics_reporter` must respond to `#add_to_counter`, `#record_value`, and `#observe_value` (if set)
 
 ### Rails cache validation and boot order
 

--- a/lib/langfuse/config.rb
+++ b/lib/langfuse/config.rb
@@ -106,6 +106,11 @@ module Langfuse
     #   results fail closed by dropping the Langfuse export batch.
     attr_accessor :mask_otel_spans
 
+    # @return [#add_to_counter, #record_value, #observe_value, nil] Reporter for
+    #   OpenTelemetry batch span processor metrics. The reporter must be fast,
+    #   thread-safe, and nonblocking. The application owns its lifecycle.
+    attr_accessor :metrics_reporter
+
     # @return [String] Default Langfuse API base URL
     DEFAULT_BASE_URL = "https://cloud.langfuse.com"
 
@@ -147,6 +152,10 @@ module Langfuse
 
     # @return [Array<Symbol>] Methods required from a custom logger
     LOGGER_METHODS = %i[debug info warn error].freeze
+
+    # Methods defined by OpenTelemetry's metrics reporter contract.
+    METRICS_REPORTER_METHODS = %i[add_to_counter record_value observe_value].freeze
+    private_constant :METRICS_REPORTER_METHODS
 
     # @return [Integer] Number of seconds representing indefinite cache duration (~1000 years)
     INDEFINITE_SECONDS = 1000 * 365 * 24 * 60 * 60
@@ -238,6 +247,7 @@ module Langfuse
       validate_callable!(should_export_span, "should_export_span")
       validate_callable!(mask, "mask")
       validate_callable!(mask_otel_spans, "mask_otel_spans")
+      validate_metrics_reporter!
       validate_logger!
     end
 
@@ -282,6 +292,7 @@ module Langfuse
       @should_export_span = nil
       @mask = nil
       @mask_otel_spans = nil
+      @metrics_reporter = nil
     end
 
     def validate_connection_settings!
@@ -369,6 +380,18 @@ module Langfuse
 
       required_methods = LOGGER_METHODS.map { |method_name| "##{method_name}" }.join(", ")
       raise ConfigurationError, "logger must respond to #{required_methods}"
+    end
+
+    def validate_metrics_reporter!
+      return if metrics_reporter.nil?
+
+      missing_methods = METRICS_REPORTER_METHODS.reject do |method_name|
+        metrics_reporter.respond_to?(method_name)
+      end
+      return if missing_methods.empty?
+
+      required_methods = METRICS_REPORTER_METHODS.map { |method_name| "##{method_name}" }.join(", ")
+      raise ConfigurationError, "metrics_reporter must respond to #{required_methods}"
     end
 
     def validate_swr_config!

--- a/lib/langfuse/otel_setup.rb
+++ b/lib/langfuse/otel_setup.rb
@@ -18,6 +18,7 @@ module Langfuse
       sample_rate
       should_export_span
       mask_otel_spans
+      metrics_reporter
       tracing_async
       batch_size
       flush_interval

--- a/lib/langfuse/resilient_metrics_reporter.rb
+++ b/lib/langfuse/resilient_metrics_reporter.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "concurrent/atomic/atomic_boolean"
+
+module Langfuse
+  # Protects trace processing from failures in an application-owned metrics reporter.
+  #
+  # @api private
+  class ResilientMetricsReporter
+    def self.wrap(reporter, logger:)
+      return if reporter.nil?
+
+      new(reporter, logger: logger)
+    end
+
+    def initialize(reporter, logger:)
+      @reporter = reporter
+      @logger = logger
+      @warning_emitted = Concurrent::AtomicBoolean.new(false)
+    end
+
+    def add_to_counter(metric, increment: 1, labels: {})
+      safely(:add_to_counter) do
+        @reporter.add_to_counter(metric, increment: increment, labels: labels)
+      end
+    end
+
+    def record_value(metric, value:, labels: {})
+      safely(:record_value) do
+        @reporter.record_value(metric, value: value, labels: labels)
+      end
+    end
+
+    def observe_value(metric, value:, labels: {})
+      safely(:observe_value) do
+        @reporter.observe_value(metric, value: value, labels: labels)
+      end
+    end
+
+    private
+
+    def safely(method_name)
+      yield
+    rescue StandardError => e
+      warn_once(method_name, e.class)
+      nil
+    end
+
+    def warn_once(method_name, error_class)
+      return unless @warning_emitted.make_true
+
+      @logger.warn(
+        "Langfuse metrics_reporter ##{method_name} failed with #{error_class}; " \
+        "future reporter failures will be suppressed"
+      )
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/lib/langfuse/span_processor.rb
+++ b/lib/langfuse/span_processor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "opentelemetry/sdk"
+require_relative "resilient_metrics_reporter"
 
 module Langfuse
   # Batch span processor that owns Langfuse's enrichment and export filtering.
@@ -19,7 +20,8 @@ module Langfuse
         exporter,
         max_queue_size: config.batch_size * 2,
         schedule_delay: schedule_delay_for(config),
-        max_export_batch_size: config.batch_size
+        max_export_batch_size: config.batch_size,
+        metrics_reporter: ResilientMetricsReporter.wrap(config.metrics_reporter, logger: config.logger)
       )
     end
 

--- a/spec/langfuse/config/tracing_metrics_reporter_spec.rb
+++ b/spec/langfuse/config/tracing_metrics_reporter_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Langfuse::Config, "#metrics_reporter" do
+  let(:config) do
+    described_class.new do |candidate|
+      candidate.public_key = "pk_test"
+      candidate.secret_key = "sk_test"
+    end
+  end
+  let(:reporter) do
+    instance_double(
+      OpenTelemetry::SDK::Trace::Export::MetricsReporter,
+      add_to_counter: nil,
+      record_value: nil,
+      observe_value: nil
+    )
+  end
+
+  it "defaults to nil" do
+    expect(config.metrics_reporter).to be_nil
+  end
+
+  it "accepts the complete OpenTelemetry reporter contract" do
+    config.metrics_reporter = reporter
+
+    expect { config.validate_tracing! }.not_to raise_error
+  end
+
+  it "reports every required method when the reporter is invalid" do
+    config.metrics_reporter = Object.new
+
+    expect { config.validate_tracing! }.to raise_error(
+      Langfuse::ConfigurationError,
+      "metrics_reporter must respond to #add_to_counter, #record_value, #observe_value"
+    )
+  end
+
+  it "rejects a reporter that implements only the methods currently called by the batch processor" do
+    incomplete_reporter = Object.new
+    def incomplete_reporter.add_to_counter(*) = nil
+    def incomplete_reporter.observe_value(*) = nil
+    config.metrics_reporter = incomplete_reporter
+
+    expect { config.validate_tracing! }.to raise_error(
+      Langfuse::ConfigurationError,
+      /#record_value/
+    )
+  end
+
+  it "keeps tracing-only reporter validity out of client readiness" do
+    config.metrics_reporter = Object.new
+
+    expect(config.valid?).to be(true)
+    expect { Langfuse::Client.new(config) }.not_to raise_error
+  end
+
+  it "fails fast when the explicit tracer provider uses an invalid reporter" do
+    Langfuse.configuration = config
+    config.metrics_reporter = Object.new
+
+    expect { Langfuse.tracer_provider }.to raise_error(
+      Langfuse::ConfigurationError,
+      /metrics_reporter must respond to/
+    )
+  end
+
+  it "warns once and uses no-op tracing for an invalid implicit reporter" do
+    logger = instance_double(Logger, debug: nil, info: nil, warn: nil, error: nil)
+    config.logger = logger
+    config.metrics_reporter = Object.new
+    Langfuse.configuration = config
+
+    expect { 2.times { Langfuse.observe("not-exported").end } }.not_to raise_error
+
+    expect(logger).to have_received(:warn).once.with(/metrics_reporter must respond to/)
+  end
+end

--- a/spec/langfuse/otel_setup_spec.rb
+++ b/spec/langfuse/otel_setup_spec.rb
@@ -65,6 +65,28 @@ RSpec.describe Langfuse::OtelSetup do
       expect(described_class.setup(config)).to equal(provider)
     end
 
+    it "requires reset before a replacement metrics reporter takes effect" do
+      first_reporter = instance_double(
+        OpenTelemetry::SDK::Trace::Export::MetricsReporter,
+        add_to_counter: nil,
+        record_value: nil,
+        observe_value: nil
+      )
+      second_reporter = instance_double(
+        OpenTelemetry::SDK::Trace::Export::MetricsReporter,
+        add_to_counter: nil,
+        record_value: nil,
+        observe_value: nil
+      )
+      config.metrics_reporter = first_reporter
+      provider = described_class.setup(config)
+      config.metrics_reporter = second_reporter
+
+      expect(logger).to receive(:warn).with(/metrics_reporter.*require Langfuse.reset!/)
+
+      expect(described_class.setup(config)).to equal(provider)
+    end
+
     it "shuts down unpublished providers lost in the setup race" do
       candidate_provider = instance_double(OpenTelemetry::SDK::Trace::TracerProvider, shutdown: nil)
       existing_provider = instance_double(OpenTelemetry::SDK::Trace::TracerProvider)

--- a/spec/langfuse/resilient_metrics_reporter_spec.rb
+++ b/spec/langfuse/resilient_metrics_reporter_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Langfuse::ResilientMetricsReporter do
+  let(:logger) { instance_double(Logger, warn: nil) }
+  let(:reporter) do
+    instance_double(
+      OpenTelemetry::SDK::Trace::Export::MetricsReporter,
+      add_to_counter: nil,
+      record_value: nil,
+      observe_value: nil
+    )
+  end
+  let(:wrapped) { described_class.wrap(reporter, logger: logger) }
+
+  it "preserves nil so OpenTelemetry uses its no-op reporter" do
+    expect(described_class.wrap(nil, logger: logger)).to be_nil
+  end
+
+  it "forwards counters without changing arguments" do
+    wrapped.add_to_counter("otel.bsp.exported_spans", increment: 3, labels: { "reason" => "test" })
+
+    expect(reporter).to have_received(:add_to_counter).with(
+      "otel.bsp.exported_spans", increment: 3, labels: { "reason" => "test" }
+    )
+  end
+
+  it "forwards recorded values without changing arguments" do
+    wrapped.record_value("otel.test.duration", value: 1.25, labels: { "unit" => "seconds" })
+
+    expect(reporter).to have_received(:record_value).with(
+      "otel.test.duration", value: 1.25, labels: { "unit" => "seconds" }
+    )
+  end
+
+  it "forwards observed values without changing arguments" do
+    wrapped.observe_value("otel.bsp.buffer_utilization", value: 0.5, labels: {})
+
+    expect(reporter).to have_received(:observe_value).with(
+      "otel.bsp.buffer_utilization", value: 0.5, labels: {}
+    )
+  end
+
+  it "suppresses reporter failures and warns once across methods" do
+    allow(reporter).to receive(:add_to_counter).and_raise("counter failed")
+    allow(reporter).to receive(:observe_value).and_raise("gauge failed")
+
+    expect { wrapped.add_to_counter("counter") }.not_to raise_error
+    expect { wrapped.observe_value("gauge", value: 1) }.not_to raise_error
+
+    expect(logger).to have_received(:warn).once.with(/#add_to_counter failed with RuntimeError/)
+  end
+
+  it "suppresses logger failures" do
+    allow(reporter).to receive(:record_value).and_raise("reporter failed")
+    allow(logger).to receive(:warn).and_raise("logger failed")
+
+    expect { wrapped.record_value("value", value: 1) }.not_to raise_error
+  end
+
+  it "emits one warning when concurrent reporter calls fail" do
+    allow(reporter).to receive(:add_to_counter).and_raise("reporter failed")
+
+    threads = 20.times.map { Thread.new { wrapped.add_to_counter("counter") } }
+    threads.each(&:value)
+
+    expect(logger).to have_received(:warn).once
+  end
+end

--- a/spec/langfuse/span_processor_metrics_spec.rb
+++ b/spec/langfuse/span_processor_metrics_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../support/blocking_span_exporter"
+
+RSpec.describe Langfuse::SpanProcessor do
+  let(:logger) { instance_double(Logger, debug: nil, info: nil, warn: nil, error: nil) }
+  let(:reporter) do
+    instance_double(
+      OpenTelemetry::SDK::Trace::Export::MetricsReporter,
+      add_to_counter: nil,
+      record_value: nil,
+      observe_value: nil
+    )
+  end
+  let(:exporter) { OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new }
+  let(:config) do
+    Langfuse::Config.new do |candidate|
+      candidate.public_key = "pk_test"
+      candidate.secret_key = "sk_test"
+      candidate.tracing_async = false
+      candidate.batch_size = 10
+      candidate.flush_interval = 30
+      candidate.metrics_reporter = reporter
+      candidate.logger = logger
+    end
+  end
+
+  def build_provider(span_exporter)
+    processor = described_class.new(config: config, exporter: span_exporter)
+    OpenTelemetry::SDK::Trace::TracerProvider.new.tap do |provider|
+      provider.add_span_processor(processor)
+    end
+  end
+
+  def finish_spans(provider, count, prefix: "span")
+    tracer = provider.tracer(Langfuse::LANGFUSE_TRACER_NAME)
+    count.times { |index| tracer.start_span("#{prefix}-#{index}").finish }
+  end
+
+  it "forwards batch processor metrics to the configured reporter" do
+    provider = build_provider(exporter)
+    finish_spans(provider, 3)
+
+    expect(provider.force_flush(timeout: 1)).to eq(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+    expect(reporter).to have_received(:add_to_counter).with(
+      "otel.bsp.exported_spans", increment: 3, labels: {}
+    )
+  ensure
+    provider&.shutdown(timeout: 1)
+  end
+
+  it "keeps span completion and export safe when the reporter raises" do
+    allow(reporter).to receive(:add_to_counter).and_raise("counter failed")
+    allow(reporter).to receive(:record_value).and_raise("value failed")
+    allow(reporter).to receive(:observe_value).and_raise("observation failed")
+    config.tracing_async = true
+    config.batch_size = 1
+    blocking_exporter = MetricsTestSupport::BlockingSpanExporter.new
+    provider = build_provider(blocking_exporter)
+    finish_spans(provider, 2)
+    blocking_exporter.wait_until_blocked
+
+    expect { finish_spans(provider, 2, prefix: "overflow") }.not_to raise_error
+    blocking_exporter.release
+
+    expect(provider.force_flush(timeout: 2)).to eq(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+    expect(blocking_exporter.finished_spans.length).to eq(3)
+    expect(logger).to have_received(:warn).once
+  ensure
+    blocking_exporter&.release
+    provider&.shutdown(timeout: 1)
+  end
+end

--- a/spec/support/blocking_span_exporter.rb
+++ b/spec/support/blocking_span_exporter.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "timeout"
+
+module MetricsTestSupport
+  class BlockingSpanExporter < OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter
+    def initialize
+      super
+      @first_export_started = Queue.new
+      @release_first_export = Queue.new
+      @first_export = true
+    end
+
+    def export(spans, timeout: nil)
+      # BatchSpanProcessor serializes exporter calls.
+      if @first_export
+        @first_export = false
+        @first_export_started << true
+        @release_first_export.pop
+      end
+      super
+    end
+
+    def wait_until_blocked(timeout: 2)
+      Timeout.timeout(timeout) { @first_export_started.pop }
+    end
+
+    def release
+      @release_first_export << true
+    end
+  end
+end


### PR DESCRIPTION
TL;DR

Adds a `config.metrics_reporter` to surface BatchSpanProcessor operational metrics (dropped spans, export failures, buffer utilization).

Why

The OTel `BatchSpanProcessor` already emits metrics through a pluggable reporter interface, but `Langfuse::SpanProcessor` never forwarded one — so otel.bsp.dropped_spans and friends were silently discarded. Under queue pressure there was no way for consumers to know spans were being lost. This wires up the existing OTel hook so applications can observe back-pressure and data loss without patching the SDK.

The default is nil, which makes the BSP fall back to its own built-in no-op reporter — zero behaviour change for current users.

Checklist
- [ ] Has label
- [ ] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in observability hook with isolated failure handling; default nil preserves current tracing behavior.
> 
> **Overview**
> Adds optional **`config.metrics_reporter`** so apps can receive OpenTelemetry **`BatchSpanProcessor`** operational metrics (e.g. exported span counts, drops, buffer pressure) that were previously discarded because Langfuse never passed a reporter into its span processor.
> 
> **`Langfuse::SpanProcessor`** now forwards a **`ResilientMetricsReporter`** wrapper into the OTel batch processor: metrics pass through unchanged, reporter exceptions are swallowed after a single warning, and span completion/export continue. **`nil`** keeps OTel’s no-op reporter—no change for existing setups.
> 
> Tracing validates the full OTel reporter contract (`add_to_counter`, `record_value`, `observe_value`) on explicit tracer setup; invalid reporters fail **`Langfuse.tracer_provider`** or degrade implicit tracing with a one-time warn. **`metrics_reporter`** is included in the tracing config snapshot, so swapping reporters requires **`Langfuse.reset!`**. Docs cover usage (including a DogStatsD adapter example) and changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d44617823111626bd306901caf0c3970b650f1ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->