### PR TITLE
feat(tracing): support custom span exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ScoreClient#create!`, `Client#create_score!`, and `Langfuse.create_score!` create scores through the synchronous Scores API, return the created score ID, and raise API errors. The existing `create` methods retain fire-and-forget ingestion batching.
 - `Langfuse.configured?` checks locally whether the global client can be constructed without accessing the network.
 - `Config#metrics_reporter` forwards OpenTelemetry batch span processor metrics to an application-owned reporter without allowing reporter failures to interrupt tracing.
+- `Config#span_exporter` lets applications inject an OpenTelemetry span exporter into Langfuse's existing tracing pipeline.
 
 ### Changed
 - Client construction now rejects invalid `batch_size` and `flush_interval` values before score batching can fail later.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -60,6 +60,7 @@ Block receives a `Langfuse::Config` object with these properties:
 | `mask`                         | `#call` | No       | `nil`                          | Mask callable for input/output/metadata (receives `data:` keyword) |
 | `mask_otel_spans`              | `#call` | No       | `nil`                          | Export-stage span masking hook (receives `params:` keyword; see [CONFIGURATION.md](CONFIGURATION.md#mask_otel_spans)) |
 | `metrics_reporter`             | Object  | No       | `nil`                          | Best-effort OpenTelemetry batch processor metrics reporter; see [CONFIGURATION.md](CONFIGURATION.md#metrics_reporter) |
+| `span_exporter`                | Object  | No       | `nil`                          | Application-supplied OpenTelemetry span exporter; see [CONFIGURATION.md](CONFIGURATION.md#span_exporter) |
 
 **Example:**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -312,6 +312,24 @@ config.tracing_async = true
 
 **Current Behavior:** Uses OpenTelemetry `BatchSpanProcessor` in both modes. Async mode uses `flush_interval` for scheduled export; sync mode uses a 60-second schedule delay and is usually paired with explicit `force_flush` for deterministic delivery timing.
 
+#### `span_exporter`
+
+- **Type:** Object responding to `export`, `force_flush`, and `shutdown`, or `nil`
+- **Default:** `nil` (uses Langfuse's OTLP exporter)
+- **Description:** Replaces the OTLP exporter inside Langfuse's tracing pipeline
+
+The supplied exporter still receives spans through Langfuse's normal sampler,
+filter, environment and release defaults, application-root tracking, masking, batch
+processor, and metrics reporter. Langfuse does not create an OTLP exporter when this
+setting is present.
+
+The internal tracer provider owns the exporter after tracing starts. The provider
+calls `shutdown` on the exporter during `Langfuse.shutdown` or `Langfuse.reset!`.
+Do not reuse a stopped exporter. Changing this setting after tracing starts requires
+`Langfuse.reset!` and a new exporter.
+
+For in-memory RSpec and Minitest recipes, see [TESTING.md](TESTING.md).
+
 #### `metrics_reporter`
 
 - **Type:** Object responding to `add_to_counter`, `record_value`, and `observe_value`, or `nil`
@@ -559,6 +577,7 @@ After the first successful tracing initialization, these settings require `Langf
 - `sample_rate`
 - `should_export_span`
 - `metrics_reporter`
+- `span_exporter`
 - `tracing_async`
 - `batch_size`
 - `flush_interval`
@@ -759,6 +778,7 @@ Tracing reuses the credential, batching, sampling, and logger rules. It also val
 - `mask` must respond to `#call` (if set)
 - `mask_otel_spans` must respond to `#call` (if set)
 - `metrics_reporter` must respond to `#add_to_counter`, `#record_value`, and `#observe_value` (if set)
+- `span_exporter` must respond to `#export`, `#force_flush`, and `#shutdown` (if set)
 
 ### Rails cache validation and boot order
 

--- a/docs/RAILS.md
+++ b/docs/RAILS.md
@@ -169,7 +169,8 @@ Passing `trace_id` is the pragmatic default. It rejoins the same trace, but it d
 
 ## Testing
 
-Reset global state between examples and stub external calls aggressively.
+For prompt and client unit tests, reset global state between examples and stub
+external calls aggressively.
 
 ```ruby
 RSpec.configure do |config|
@@ -178,6 +179,11 @@ RSpec.configure do |config|
   end
 end
 ```
+
+Do not combine this reset hook with a process-level injected span exporter.
+`Langfuse.reset!` shuts down that exporter. To assert real spans through the normal
+Langfuse processor, use the application-owned exporter recipe in
+[TESTING.md](TESTING.md).
 
 Stub prompt fetches at the client boundary:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This is the consumer hub. Start here unless you are already looking for a specif
 3. **[Tracing](TRACING.md)** — Root observations, nested generations, events, propagation, and OpenTelemetry ownership
 4. **[Scoring](SCORING.md)** — Add evaluation and feedback signals to traces and observations
 5. **[Rails](RAILS.md)** — Applied controller, service, job, testing, and operational patterns
+6. **[Testing tracing](TESTING.md)** — In-memory exporter recipes and lifecycle constraints
 
 ## By Intent
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,122 @@
+# Testing Tracing
+
+Use an application-owned in-memory exporter when a test must inspect completed
+Langfuse spans. This approach runs observations through Langfuse's normal sampler,
+filter, enrichment, masking, batch processor, and exporter pipeline. It does not
+send trace data over HTTP.
+
+## RSpec
+
+Create one exporter for the test process. Configure it before tracing starts.
+Dummy API keys are still required because tracing validates all connection settings.
+
+```ruby
+# spec/support/langfuse.rb
+require "opentelemetry/sdk"
+
+LANGFUSE_TEST_EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+
+Langfuse.configure do |config|
+  config.public_key = "pk-test"
+  config.secret_key = "sk-test"
+  config.span_exporter = LANGFUSE_TEST_EXPORTER
+end
+
+RSpec.configure do |config|
+  config.around(:each, :langfuse) do |example|
+    Langfuse.force_flush
+    LANGFUSE_TEST_EXPORTER.reset
+
+    begin
+      example.run
+    ensure
+      Langfuse.force_flush
+    end
+  end
+end
+```
+
+Flush before each assertion because Langfuse uses the normal batch processor.
+
+```ruby
+RSpec.describe SummarizationService, :langfuse do
+  it "emits a generation span" do
+    described_class.call("hello")
+    Langfuse.force_flush
+
+    span = LANGFUSE_TEST_EXPORTER.finished_spans.find { |item| item.name == "summarize" }
+    expect(span.attributes["langfuse.observation.type"]).to eq("generation")
+  end
+end
+```
+
+## Minitest
+
+The same process-level exporter works with Minitest. Use lifecycle callbacks to
+flush old work before clearing the buffer and to flush completed test work during
+teardown.
+
+```ruby
+# test/support/langfuse.rb
+require "opentelemetry/sdk"
+
+LANGFUSE_TEST_EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+
+Langfuse.configure do |config|
+  config.public_key = "pk-test"
+  config.secret_key = "sk-test"
+  config.span_exporter = LANGFUSE_TEST_EXPORTER
+end
+
+module LangfuseTestTracing
+  def before_setup
+    super
+    Langfuse.force_flush
+    LANGFUSE_TEST_EXPORTER.reset
+  end
+
+  def after_teardown
+    Langfuse.force_flush
+    super
+  end
+end
+```
+
+Include the module in tests that inspect spans:
+
+```ruby
+class SummarizationServiceTest < ActiveSupport::TestCase
+  include LangfuseTestTracing
+
+  test "emits a generation span" do
+    SummarizationService.call("hello")
+    Langfuse.force_flush
+
+    span = LANGFUSE_TEST_EXPORTER.finished_spans.find { |item| item.name == "summarize" }
+    assert_equal "generation", span.attributes["langfuse.observation.type"]
+  end
+end
+```
+
+## Lifecycle and Concurrency
+
+Langfuse's internal tracer provider owns the configured exporter after tracing
+starts. `Langfuse.shutdown` and `Langfuse.reset!` shut down that exporter. Do not
+reuse the exporter after either call. Create and configure a new exporter when you
+rebuild tracing.
+
+Prefer `Langfuse.force_flush` and `InMemorySpanExporter#reset` between examples.
+`Langfuse.reset!` also rebuilds the prompt and score client, so it is not a
+tracing-only test reset.
+
+A span that starts before an exporter buffer reset and finishes afterward can appear
+in the next example. Finish all jobs and threads before assertions. Serialize tests
+that emit Langfuse spans. Process-based parallel workers have separate exporters and
+are safe. Thread-based parallel examples must be serialized.
+
+This recipe is unsupported after an application assigns
+`OpenTelemetry.tracer_provider = Langfuse.tracer_provider`. That assignment makes
+Langfuse's provider process-global and extends its lifecycle beyond this recipe.
+
+Changing `span_exporter` after tracing starts produces a warning. The active provider
+keeps its original exporter until `Langfuse.reset!` rebuilds tracing.

--- a/lib/langfuse/config.rb
+++ b/lib/langfuse/config.rb
@@ -111,6 +111,11 @@ module Langfuse
     #   thread-safe, and nonblocking. The application owns its lifecycle.
     attr_accessor :metrics_reporter
 
+    # @return [#export, #force_flush, #shutdown, nil] Span exporter used by
+    #   Langfuse's internal tracer provider. The provider owns the exporter
+    #   lifecycle after tracing starts. nil selects the default OTLP exporter.
+    attr_accessor :span_exporter
+
     # @return [String] Default Langfuse API base URL
     DEFAULT_BASE_URL = "https://cloud.langfuse.com"
 
@@ -156,6 +161,10 @@ module Langfuse
     # Methods defined by OpenTelemetry's metrics reporter contract.
     METRICS_REPORTER_METHODS = %i[add_to_counter record_value observe_value].freeze
     private_constant :METRICS_REPORTER_METHODS
+
+    # Methods required by OpenTelemetry's span exporter contract.
+    SPAN_EXPORTER_METHODS = %i[export force_flush shutdown].freeze
+    private_constant :SPAN_EXPORTER_METHODS
 
     # @return [Integer] Number of seconds representing indefinite cache duration (~1000 years)
     INDEFINITE_SECONDS = 1000 * 365 * 24 * 60 * 60
@@ -248,6 +257,7 @@ module Langfuse
       validate_callable!(mask, "mask")
       validate_callable!(mask_otel_spans, "mask_otel_spans")
       validate_metrics_reporter!
+      validate_span_exporter!
       validate_logger!
     end
 
@@ -293,6 +303,7 @@ module Langfuse
       @mask = nil
       @mask_otel_spans = nil
       @metrics_reporter = nil
+      @span_exporter = nil
     end
 
     def validate_connection_settings!
@@ -392,6 +403,18 @@ module Langfuse
 
       required_methods = METRICS_REPORTER_METHODS.map { |method_name| "##{method_name}" }.join(", ")
       raise ConfigurationError, "metrics_reporter must respond to #{required_methods}"
+    end
+
+    def validate_span_exporter!
+      return if span_exporter.nil?
+
+      missing_methods = SPAN_EXPORTER_METHODS.reject do |method_name|
+        span_exporter.respond_to?(method_name)
+      end
+      return if missing_methods.empty?
+
+      required_methods = SPAN_EXPORTER_METHODS.map { |method_name| "##{method_name}" }.join(", ")
+      raise ConfigurationError, "span_exporter must respond to #{required_methods}"
     end
 
     def validate_swr_config!

--- a/lib/langfuse/otel_setup.rb
+++ b/lib/langfuse/otel_setup.rb
@@ -19,6 +19,7 @@ module Langfuse
       should_export_span
       mask_otel_spans
       metrics_reporter
+      span_exporter
       tracing_async
       batch_size
       flush_interval
@@ -35,19 +36,9 @@ module Langfuse
       # @return [OpenTelemetry::SDK::Trace::TracerProvider]
       def setup(config)
         config.validate_tracing!
-        return existing_provider_for(config) if initialized?
+        provider, created = setup_mutex.synchronize { setup_locked(config) }
 
-        candidate_provider = nil
-        provider = nil
-        created = false
-        candidate_provider = build_tracer_provider(config)
-        provider, created = publish_provider(candidate_provider, tracing_config_snapshot(config))
-        unless created
-          candidate_provider.shutdown(timeout: 30)
-          return existing_provider_for(config)
-        end
-
-        log_initialized(config)
+        log_initialized(config) if created
         provider
       rescue StandardError
         rollback_provider(provider) if created
@@ -98,23 +89,13 @@ module Langfuse
         @tracer_provider
       end
 
-      def publish_provider(provider, snapshot)
-        created = false
-        current = nil
+      def setup_locked(config)
+        return [existing_provider_for(config), false] if @tracer_provider
 
-        # This mutex only guards publication so setup never exposes a half-built provider.
-        setup_mutex.synchronize do
-          if @tracer_provider
-            current = @tracer_provider
-          else
-            @tracer_provider = provider
-            @config_snapshot = snapshot
-            current = provider
-            created = true
-          end
-        end
-
-        [current, created]
+        provider = build_tracer_provider(config)
+        @tracer_provider = provider
+        @config_snapshot = tracing_config_snapshot(config)
+        [provider, true]
       end
 
       def rollback_provider(provider)
@@ -140,14 +121,18 @@ module Langfuse
       end
 
       def build_exporter(config)
-        exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(
+        exporter = config.span_exporter || build_otlp_exporter(config)
+        return exporter unless config.mask_otel_spans
+
+        MaskingExporter.new(delegate: exporter, hook: config.mask_otel_spans, logger: config.logger)
+      end
+
+      def build_otlp_exporter(config)
+        OpenTelemetry::Exporter::OTLP::Exporter.new(
           endpoint: "#{config.base_url}/api/public/otel/v1/traces",
           headers: build_headers(config.public_key, config.secret_key),
           compression: "gzip"
         )
-        return exporter unless config.mask_otel_spans
-
-        MaskingExporter.new(delegate: exporter, hook: config.mask_otel_spans, logger: config.logger)
       end
 
       def log_initialized(config)

--- a/spec/langfuse/config/tracing_span_exporter_spec.rb
+++ b/spec/langfuse/config/tracing_span_exporter_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Langfuse::Config, "#span_exporter" do
+  let(:config) do
+    described_class.new do |candidate|
+      candidate.public_key = "pk_test"
+      candidate.secret_key = "sk_test"
+    end
+  end
+
+  let(:exporter) do
+    instance_double(
+      OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter,
+      export: OpenTelemetry::SDK::Trace::Export::SUCCESS,
+      force_flush: OpenTelemetry::SDK::Trace::Export::SUCCESS,
+      shutdown: OpenTelemetry::SDK::Trace::Export::SUCCESS
+    )
+  end
+
+  it "defaults to nil" do
+    expect(config.span_exporter).to be_nil
+  end
+
+  it "accepts an exporter that implements the OpenTelemetry contract" do
+    config.span_exporter = exporter
+
+    expect { config.validate_tracing! }.not_to raise_error
+  end
+
+  it "rejects an exporter that does not implement the OpenTelemetry contract" do
+    config.span_exporter = Object.new
+
+    expect { config.validate_tracing! }.to raise_error(
+      Langfuse::ConfigurationError,
+      "span_exporter must respond to #export, #force_flush, #shutdown"
+    )
+  end
+
+  it "keeps exporter validation out of client-only validation" do
+    config.span_exporter = Object.new
+
+    expect { config.validate! }.not_to raise_error
+  end
+end

--- a/spec/langfuse/otel_setup_spec.rb
+++ b/spec/langfuse/otel_setup_spec.rb
@@ -5,6 +5,14 @@ require "spec_helper"
 RSpec.describe Langfuse::OtelSetup do
   let(:logger) { instance_double(Logger, info: nil, debug: nil, warn: nil, error: nil) }
   let(:exporter) { OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new }
+  let(:metrics_reporter) do
+    instance_double(
+      OpenTelemetry::SDK::Trace::Export::MetricsReporter,
+      add_to_counter: nil,
+      record_value: nil,
+      observe_value: nil
+    )
+  end
   let(:config) do
     Langfuse::Config.new do |c|
       c.public_key = "pk_test_123"
@@ -14,12 +22,12 @@ RSpec.describe Langfuse::OtelSetup do
       c.batch_size = 10
       c.flush_interval = 1
       c.logger = logger
+      c.span_exporter = exporter
     end
   end
 
   before do
     described_class.shutdown(timeout: 1) if described_class.initialized?
-    allow(described_class).to receive(:build_exporter).and_return(exporter)
   end
 
   after do
@@ -87,18 +95,14 @@ RSpec.describe Langfuse::OtelSetup do
       expect(described_class.setup(config)).to equal(provider)
     end
 
-    it "shuts down unpublished providers lost in the setup race" do
-      candidate_provider = instance_double(OpenTelemetry::SDK::Trace::TracerProvider, shutdown: nil)
-      existing_provider = instance_double(OpenTelemetry::SDK::Trace::TracerProvider)
+    it "keeps an injected exporter live during concurrent setup" do
+      providers = Queue.new
+      threads = 5.times.map { Thread.new { providers << described_class.setup(config) } }
+      threads.each(&:join)
 
-      allow(described_class).to receive_messages(
-        build_tracer_provider: candidate_provider,
-        publish_provider: [existing_provider, false],
-        existing_provider_for: existing_provider
-      )
-
-      expect(candidate_provider).to receive(:shutdown).with(timeout: 30)
-      expect(described_class.setup(config)).to equal(existing_provider)
+      resolved = 5.times.map { providers.pop }
+      expect(resolved.map(&:object_id).uniq.length).to eq(1)
+      expect(exporter.export([])).to eq(OpenTelemetry::SDK::Trace::Export::SUCCESS)
     end
 
     it "validates should_export_span in setup" do
@@ -191,7 +195,14 @@ RSpec.describe Langfuse::OtelSetup do
   end
 
   describe ".build_exporter transport" do
+    it "uses an injected exporter without constructing OTLP" do
+      expect(OpenTelemetry::Exporter::OTLP::Exporter).not_to receive(:new)
+
+      expect(described_class.send(:build_exporter, config)).to equal(exporter)
+    end
+
     it "configures direct v4 OTLP ingestion without changing transport settings" do
+      config.span_exporter = nil
       expected_headers = {
         "Authorization" => "Basic #{Base64.strict_encode64('pk_test_123:sk_test_456')}",
         "x-langfuse-ingestion-version" => "4",
@@ -281,6 +292,7 @@ RSpec.describe Langfuse::OtelSetup do
         c.batch_size = 10
         c.flush_interval = 1
         c.logger = logger
+        c.span_exporter = exporter
       end
     end
 
@@ -322,6 +334,7 @@ RSpec.describe Langfuse::OtelSetup do
         c.tracing_async = false
         c.should_export_span = ->(_span) { false }
         c.logger = logger
+        c.span_exporter = exporter
       end
 
       OpenTelemetry.tracer_provider = Langfuse.tracer_provider
@@ -329,6 +342,38 @@ RSpec.describe Langfuse::OtelSetup do
       Langfuse.force_flush(timeout: 1)
 
       expect(exporter.finished_spans).to be_empty
+    end
+
+    it "keeps filtering, defaults, app-root tracking, and metrics in the injected pipeline" do
+      Langfuse.reset!
+      Langfuse.configure do |c|
+        c.public_key = config.public_key
+        c.secret_key = config.secret_key
+        c.tracing_async = false
+        c.environment = "test"
+        c.release = "release-123"
+        c.should_export_span = ->(span) { span.name != "drop-me" }
+        c.metrics_reporter = metrics_reporter
+        c.span_exporter = exporter
+        c.logger = logger
+      end
+
+      Langfuse.observe("root") do |root|
+        root.start_observation("child") { |child| child.update(output: "ok") }
+      end
+      Langfuse.observe("drop-me") { |span| span.update(output: "discarded") }
+      Langfuse.force_flush(timeout: 1)
+
+      spans = exporter.finished_spans.to_h { |span| [span.name, span] }
+      expect(spans.keys).to contain_exactly("root", "child")
+      expect(spans.fetch("root").attributes).to include(
+        Langfuse::OtelAttributes::ENVIRONMENT => "test",
+        Langfuse::OtelAttributes::RELEASE => "release-123",
+        Langfuse::OtelAttributes::IS_APP_ROOT => true
+      )
+      expect(metrics_reporter).to have_received(:add_to_counter).with(
+        "otel.bsp.exported_spans", increment: 2, labels: {}
+      )
     end
   end
 
@@ -338,12 +383,19 @@ RSpec.describe Langfuse::OtelSetup do
     end
 
     it "returns the plain OTLP exporter when mask_otel_spans is nil" do
+      config.span_exporter = nil
       expect(described_class.send(:build_exporter, config)).to be_a(OpenTelemetry::Exporter::OTLP::Exporter)
     end
 
-    it "wraps the OTLP exporter in a MaskingExporter when mask_otel_spans is configured" do
+    it "wraps an injected exporter in a MaskingExporter when mask_otel_spans is configured" do
       config.mask_otel_spans = ->(**) {}
-      expect(described_class.send(:build_exporter, config)).to be_a(Langfuse::MaskingExporter)
+      allow(exporter).to receive(:force_flush).and_call_original
+
+      masked_exporter = described_class.send(:build_exporter, config)
+      masked_exporter.force_flush(timeout: 1)
+
+      expect(masked_exporter).to be_a(Langfuse::MaskingExporter)
+      expect(exporter).to have_received(:force_flush).with(timeout: 1)
     end
   end
 
@@ -363,7 +415,6 @@ RSpec.describe Langfuse::OtelSetup do
 
     before do
       allow(described_class).to receive(:build_exporter).and_call_original
-      allow(OpenTelemetry::Exporter::OTLP::Exporter).to receive(:new).and_return(exporter)
       Langfuse.reset!
       Langfuse.configure do |c|
         c.public_key = config.public_key
@@ -371,6 +422,7 @@ RSpec.describe Langfuse::OtelSetup do
         c.base_url = config.base_url
         c.tracing_async = false
         c.mask_otel_spans = mask_hook
+        c.span_exporter = exporter
         c.logger = logger
       end
     end
@@ -391,6 +443,82 @@ RSpec.describe Langfuse::OtelSetup do
       Langfuse.force_flush(timeout: 1)
 
       expect(seen_spans.map(&:name)).to eq(["llm-call"])
+    end
+  end
+
+  describe "injected exporter lifecycle" do
+    def build_config(span_exporter)
+      Langfuse::Config.new do |candidate|
+        candidate.public_key = "pk_test"
+        candidate.secret_key = "sk_test"
+        candidate.tracing_async = false
+        candidate.span_exporter = span_exporter
+        candidate.logger = logger
+      end
+    end
+
+    def finish_span(provider, name)
+      provider.tracer(Langfuse::LANGFUSE_TRACER_NAME).start_span(name).finish
+    end
+
+    it "warns and keeps the active exporter until reset" do
+      replacement = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+      provider = described_class.setup(config)
+      config.span_exporter = replacement
+
+      expect(logger).to receive(:warn).with(/span_exporter.*require Langfuse.reset!/)
+      expect(described_class.setup(config)).to equal(provider)
+      finish_span(provider, "first-exporter")
+      described_class.force_flush(timeout: 1)
+
+      expect(exporter.finished_spans.map(&:name)).to eq(["first-exporter"])
+      expect(replacement.finished_spans).to be_empty
+    end
+
+    it "shuts down the injected exporter with its provider" do
+      described_class.setup(config)
+
+      described_class.shutdown(timeout: 1)
+
+      expect(exporter.export([])).to eq(OpenTelemetry::SDK::Trace::Export::FAILURE)
+    end
+
+    it "shuts down the injected exporter during Langfuse.reset!" do
+      Langfuse.configuration = config
+      Langfuse.tracer_provider
+
+      Langfuse.reset!
+
+      expect(exporter.export([])).to eq(OpenTelemetry::SDK::Trace::Export::FAILURE)
+    end
+
+    it "keeps consecutive exporter sessions isolated" do
+      first_provider = described_class.setup(config)
+      finish_span(first_provider, "first-session")
+      described_class.force_flush(timeout: 1)
+      expect(exporter.finished_spans.map(&:name)).to eq(["first-session"])
+      described_class.shutdown(timeout: 1)
+
+      second_exporter = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+      second_provider = described_class.setup(build_config(second_exporter))
+      finish_span(second_provider, "second-session")
+      described_class.force_flush(timeout: 1)
+
+      expect(second_exporter.finished_spans.map(&:name)).to eq(["second-session"])
+    end
+
+    it "does not send a late span from a stopped provider to the next exporter" do
+      first_provider = described_class.setup(config)
+      late_span = first_provider.tracer(Langfuse::LANGFUSE_TRACER_NAME).start_span("late-first")
+      described_class.shutdown(timeout: 1)
+
+      second_exporter = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+      second_provider = described_class.setup(build_config(second_exporter))
+      finish_span(second_provider, "second-session")
+      late_span.finish
+      described_class.force_flush(timeout: 1)
+
+      expect(second_exporter.finished_spans.map(&:name)).to eq(["second-session"])
     end
   end
 end


### PR DESCRIPTION
#### `TL;DR`
<!-- One sentence -->
Applications can inject an OpenTelemetry span exporter while Langfuse keeps ownership of its tracing pipeline.

#### `Why`
<!-- Motivation/context for this change -->
Applications need to test observed code without network requests or Langfuse method stubs. A generic exporter setting provides that workflow without process-global test mode.

#### `Checklist`
- [ ] Has label
- [ ] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)

> [!NOTE]
> **Kade's words:**
>
> Drop the capture helper from PR 100. Ship `Config#span_exporter` and an app-owned recipe.

## Summary

Applications can now set `Config#span_exporter` before tracing starts. Langfuse sends accepted spans through its existing sampler, filter, enrichment, masking, batch processor, and metrics path before it calls the supplied exporter. A `nil` value keeps the existing OTLP exporter.

This change lets RSpec and Minitest suites inspect in-memory spans without HTTP requests or private SDK access. The application owns setup and buffer reset. The Langfuse tracer provider owns exporter shutdown.

The PR does not add `Langfuse::Testing`, `test_mode`, capture helpers, or tracer-provider injection. Tests that emit spans on parallel threads must serialize that work and finish background jobs before assertions.

### Change diagram

```mermaid
flowchart LR
  accTitle: Custom span exporter flow
  accDescr: Langfuse processes each span before it selects the default OTLP exporter or an application exporter.
  A["Langfuse.observe"] --> B["Langfuse SpanProcessor"]
  B --> C{"Masking configured?"}
  C -- "Yes" --> D["MaskingExporter"]
  C -- "No" --> E{"span_exporter set?"}
  D --> E
  E -- "Yes" --> F["Application exporter"]
  E -- "No" --> G["Langfuse OTLP exporter"]
```

The exporter selection changes. The Langfuse processing path remains the same.

## Verification

I validated the change locally on Ruby 3.2. The full suite passed with 1,570 examples and 97.25% line coverage. RuboCop inspected 96 files with no offenses.

I ran the same suite in Ruby 3.3 and Ruby 3.4 Linux containers. Both runs passed all 1,570 examples with 97.25% line coverage.

I built and installed the gem in an isolated consumer. The consumer exported one in-memory span and WebMock recorded zero HTTP requests. A Rails 8.0.5.1 Minitest consumer also passed three assertions with zero HTTP requests.

I validated the unchanged default OTLP path with synthetic data. Langfuse returned a root span and nested generation through the Observations API. Both observations had the expected types, environment, input, and output.

Hosted CI passed for commit `6f6c9f6`. The run covered Ruby 3.2, Ruby 3.3, Ruby 3.4, RuboCop, and Wiz. Cursor Bugbot completed with no unresolved comments on the current head. I reviewed the Mermaid syntax but did not preview the rendered diagram in GitHub.