### PR TITLE
feat(scoring): add ScoreClient#create!, Client#create_score!, Langfuse.create_score!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `ScoreClient#create!`, `Client#create_score!`, and `Langfuse.create_score!` — synchronous score creation that bypasses the in-memory queue and trace-sampling gate, sending immediately and raising (`UnauthorizedError`/`ApiError`) on delivery failure. For standalone scores arriving out-of-band (e.g. user feedback) where the caller needs to know the outcome to decide whether to retry, as opposed to `create`'s fire-and-forget batching.
+- `ScoreClient#create!`, `Client#create_score!`, and `Langfuse.create_score!` create scores through the synchronous Scores API, return the created score ID, and raise API errors. The existing `create` methods retain fire-and-forget ingestion batching.
 
 ## [0.10.1] - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `ScoreClient#create!`, `Client#create_score!`, and `Langfuse.create_score!` — synchronous score creation that bypasses the in-memory queue and trace-sampling gate, sending immediately and raising (`UnauthorizedError`/`ApiError`) on delivery failure. For standalone scores arriving out-of-band (e.g. user feedback) where the caller needs to know the outcome to decide whether to retry, as opposed to `create`'s fire-and-forget batching.
+
 ## [0.10.1] - 2026-05-05
 
 ### Changed

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -936,7 +936,7 @@ create_score(name:, value:, id: nil, trace_id: nil, session_id: nil, observation
 | `comment`        | String                 | No       | Score comment                             |
 | `metadata`       | Hash                   | No       | Additional metadata                       |
 | `environment`    | String                 | No       | Environment tag for the score             |
-| `data_type`      | Symbol                 | No       | `:numeric`, `:boolean`, or `:categorical` |
+| `data_type`      | Symbol                 | No       | `:numeric`, `:boolean`, `:categorical`, `:text`, or `:correction` |
 | `dataset_run_id` | String                 | No       | Dataset run ID to associate with          |
 | `config_id`      | String                 | No       | Score config ID                           |
 
@@ -954,15 +954,15 @@ client.create_score(
 
 ### `Client#create_score!`
 
-Create a score for a trace or observation, sent immediately instead of queued.
+Create a score through the synchronous Scores API instead of the ingestion queue.
 
-Same parameters as `create_score`, but bypasses the in-memory batching queue
-and the trace-sampling gate, sending synchronously and raising on failure.
-Use this for a standalone score arriving out-of-band — e.g. user feedback in
-a request unrelated to the turn it's scoring — where the caller needs to know
-whether delivery succeeded in order to retry. `create_score` remains the
-right choice for scoring inline from a still-open span, where fire-and-forget
-matches how the rest of this SDK's tracing already works.
+The method returns the created score ID after Langfuse accepts the request.
+It bypasses the in-memory queue and trace-sampling gate. Use `create_score`
+for fire-and-forget batching.
+
+For retryable workflows, generate a stable `id` before the first request and
+reuse the complete score payload. A network failure can occur after Langfuse
+accepts a request, so the failure alone does not prove that the score was rejected.
 
 **Signature:**
 
@@ -972,16 +972,21 @@ create_score!(name:, value:, id: nil, trace_id: nil, session_id: nil, observatio
               dataset_run_id: nil, config_id: nil)
 ```
 
+**Returns:** The created score ID as a String
+
 **Raises:** `ArgumentError` for invalid input; `UnauthorizedError` on a 401; `ApiError` for any other API failure
 
 **Example:**
 
 ```ruby
-begin
-  client.create_score!(name: "thumbs_up", value: true, trace_id: trace_id, data_type: :boolean)
-rescue Langfuse::ApiError => e
-  # retry, alert, etc. — the score was not delivered
-end
+score_id = "user-thumbs-#{trace_id}"
+created_id = client.create_score!(
+  id: score_id,
+  name: "user-thumbs",
+  value: true,
+  trace_id: trace_id,
+  data_type: :boolean
+)
 ```
 
 ### `Client#score_active_observation`
@@ -1037,7 +1042,7 @@ Convenience methods delegating to `Langfuse.client`:
 
 ```ruby
 Langfuse.create_score(name: "quality", value: 0.85, trace_id: "abc")
-Langfuse.create_score!(name: "quality", value: 0.85, trace_id: "abc") # sends immediately, raises on failure
+score_id = Langfuse.create_score!(name: "quality", value: 0.85, trace_id: "abc")
 Langfuse.score_active_observation(name: "quality", value: 0.9, data_type: :numeric)
 Langfuse.score_active_trace(name: "overall", value: 5, data_type: :numeric)
 Langfuse.flush_scores

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -952,6 +952,38 @@ client.create_score(
 )
 ```
 
+### `Client#create_score!`
+
+Create a score for a trace or observation, sent immediately instead of queued.
+
+Same parameters as `create_score`, but bypasses the in-memory batching queue
+and the trace-sampling gate, sending synchronously and raising on failure.
+Use this for a standalone score arriving out-of-band — e.g. user feedback in
+a request unrelated to the turn it's scoring — where the caller needs to know
+whether delivery succeeded in order to retry. `create_score` remains the
+right choice for scoring inline from a still-open span, where fire-and-forget
+matches how the rest of this SDK's tracing already works.
+
+**Signature:**
+
+```ruby
+create_score!(name:, value:, id: nil, trace_id: nil, session_id: nil, observation_id: nil,
+              comment: nil, metadata: nil, environment: nil, data_type: :numeric,
+              dataset_run_id: nil, config_id: nil)
+```
+
+**Raises:** `ArgumentError` for invalid input; `UnauthorizedError` on a 401; `ApiError` for any other API failure
+
+**Example:**
+
+```ruby
+begin
+  client.create_score!(name: "thumbs_up", value: true, trace_id: trace_id, data_type: :boolean)
+rescue Langfuse::ApiError => e
+  # retry, alert, etc. — the score was not delivered
+end
+```
+
 ### `Client#score_active_observation`
 
 Score the currently active observation (from OTel context).
@@ -1005,6 +1037,7 @@ Convenience methods delegating to `Langfuse.client`:
 
 ```ruby
 Langfuse.create_score(name: "quality", value: 0.85, trace_id: "abc")
+Langfuse.create_score!(name: "quality", value: 0.85, trace_id: "abc") # sends immediately, raises on failure
 Langfuse.score_active_observation(name: "quality", value: 0.9, data_type: :numeric)
 Langfuse.score_active_trace(name: "overall", value: 5, data_type: :numeric)
 Langfuse.flush_scores

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -259,6 +259,48 @@ module Langfuse
     end
     # rubocop:enable Metrics/ParameterLists
 
+    # Create a score event and send it immediately, bypassing the in-memory
+    # queue and the trace-sampling gate. See {ScoreClient#create!}.
+    #
+    # @param name [String] Score name (required)
+    # @param value [Numeric, Integer, String] Score value (type depends on data_type)
+    # @param id [String, nil] Score ID
+    # @param trace_id [String, nil] Trace ID to associate with the score
+    # @param session_id [String, nil] Session ID to associate with the score
+    # @param observation_id [String, nil] Observation ID to associate with the score
+    # @param comment [String, nil] Optional comment
+    # @param metadata [Hash, nil] Optional metadata hash
+    # @param environment [String, nil] Optional environment
+    # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
+    # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
+    # @param config_id [String, nil] Optional score config ID
+    # @return [void]
+    # @raise [ArgumentError] if validation fails
+    # @raise [UnauthorizedError] if authentication fails
+    # @raise [ApiError] if the API request fails
+    #
+    # @example
+    #   Langfuse.create_score!(name: "quality", value: 0.85, trace_id: "abc123")
+    # rubocop:disable Metrics/ParameterLists
+    def create_score!(name:, value:, id: nil, trace_id: nil, session_id: nil, observation_id: nil, comment: nil,
+                      metadata: nil, environment: nil, data_type: :numeric, dataset_run_id: nil, config_id: nil)
+      client.create_score!(
+        name: name,
+        value: value,
+        id: id,
+        trace_id: trace_id,
+        session_id: session_id,
+        observation_id: observation_id,
+        comment: comment,
+        metadata: metadata,
+        environment: environment,
+        data_type: data_type,
+        dataset_run_id: dataset_run_id,
+        config_id: config_id
+      )
+    end
+    # rubocop:enable Metrics/ParameterLists
+
     # Create a score for the currently active observation (from OTel span)
     #
     # Extracts observation_id and trace_id from the active OpenTelemetry span.

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -218,7 +218,7 @@ module Langfuse
     #
     # @param name [String] Score name (required)
     # @param value [Numeric, Integer, String] Score value (type depends on data_type)
-    # @param id [String, nil] Score ID
+    # @param id [String, nil] Score ID; use a stable value as an idempotency key
     # @param trace_id [String, nil] Trace ID to associate with the score
     # @param session_id [String, nil] Session ID to associate with the score
     # @param observation_id [String, nil] Observation ID to associate with the score
@@ -259,12 +259,11 @@ module Langfuse
     end
     # rubocop:enable Metrics/ParameterLists
 
-    # Create a score event and send it immediately, bypassing the in-memory
-    # queue and the trace-sampling gate. See {ScoreClient#create!}.
+    # Create a score immediately through the Scores API. See {ScoreClient#create!}.
     #
     # @param name [String] Score name (required)
     # @param value [Numeric, Integer, String] Score value (type depends on data_type)
-    # @param id [String, nil] Score ID
+    # @param id [String, nil] Score ID; use a stable value as an idempotency key
     # @param trace_id [String, nil] Trace ID to associate with the score
     # @param session_id [String, nil] Session ID to associate with the score
     # @param observation_id [String, nil] Observation ID to associate with the score
@@ -274,13 +273,13 @@ module Langfuse
     # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
     # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
     # @param config_id [String, nil] Optional score config ID
-    # @return [void]
+    # @return [String] ID of the created score
     # @raise [ArgumentError] if validation fails
     # @raise [UnauthorizedError] if authentication fails
     # @raise [ApiError] if the API request fails
     #
-    # @example
-    #   Langfuse.create_score!(name: "quality", value: 0.85, trace_id: "abc123")
+    # @example Create a score with an idempotency key
+    #   Langfuse.create_score!(id: "feedback-abc123", name: "quality", value: 0.85, trace_id: "abc123")
     # rubocop:disable Metrics/ParameterLists
     def create_score!(name:, value:, id: nil, trace_id: nil, session_id: nil, observation_id: nil, comment: nil,
                       metadata: nil, environment: nil, data_type: :numeric, dataset_run_id: nil, config_id: nil)

--- a/lib/langfuse/api_client.rb
+++ b/lib/langfuse/api_client.rb
@@ -304,6 +304,20 @@ module Langfuse
       raise ApiError, "Batch send failed: #{e.message}"
     end
 
+    # Create a score through the synchronous Scores API.
+    #
+    # @param payload [Hash] Validated score attributes in API format
+    # @return [String] ID of the created score
+    # @raise [UnauthorizedError] if authentication fails
+    # @raise [ApiError] if the API request fails or omits the created score ID
+    def create_score(payload:)
+      response = request(:post, "/api/public/scores", body: payload)
+      score_id = response["id"]
+      return score_id if score_id.is_a?(String) && !score_id.empty?
+
+      raise ApiError, "Score creation response did not include an id"
+    end
+
     # Create a dataset run item (link a trace to a dataset item within a run)
     #
     # @param dataset_item_id [String] Dataset item ID (required)
@@ -689,7 +703,7 @@ module Langfuse
     # - Max 2 retries (3 total attempts)
     # - Exponential backoff (0.05s * 2^retry_count)
     # - Retries GET, PATCH, and DELETE requests (idempotent operations)
-    # - Retries POST requests to batch endpoint (idempotent due to event UUIDs)
+    # - Retries ingestion batches and score creation (both include stable IDs)
     # - Note: POST to create_prompt is NOT idempotent; retries may create duplicate versions
     # - Retries on: 429 (rate limit), 503 (service unavailable), 504 (gateway timeout)
     # - Does NOT retry on: 4xx errors (except 429), 5xx errors (except 503, 504)
@@ -780,11 +794,11 @@ module Langfuse
 
     # Handle HTTP response for batch requests
     #
-    # Ingestion never returns a 4xx for rejected events — per the endpoint's
-    # own spec, "input errors" surface as a 200-series/207 response whose body
-    # lists them instead. That `errors` array is the only real per-event
-    # success/failure signal; HTTP status alone can't distinguish a fully
-    # accepted batch from a fully rejected one.
+    # Per-event input errors can arrive with HTTP 207 instead of a 4xx response.
+    # The `errors` array reports rejected events, so HTTP status alone cannot
+    # identify a batch with rejected events. An empty array confirms only that
+    # the response reported no rejection; it does not prove downstream
+    # processing or immediate read visibility.
     #
     # @param response [Faraday::Response] The HTTP response
     # @return [void]

--- a/lib/langfuse/api_client.rb
+++ b/lib/langfuse/api_client.rb
@@ -780,14 +780,20 @@ module Langfuse
 
     # Handle HTTP response for batch requests
     #
+    # Ingestion never returns a 4xx for rejected events — per the endpoint's
+    # own spec, "input errors" surface as a 200-series/207 response whose body
+    # lists them instead. That `errors` array is the only real per-event
+    # success/failure signal; HTTP status alone can't distinguish a fully
+    # accepted batch from a fully rejected one.
+    #
     # @param response [Faraday::Response] The HTTP response
     # @return [void]
     # @raise [UnauthorizedError] if status is 401
-    # @raise [ApiError] for other error statuses
+    # @raise [ApiError] for other error statuses, or if the body lists rejected events
     def handle_batch_response(response)
       case response.status
       when 200, 201, 204, 207
-        nil
+        raise_on_batch_errors(response)
       when 401
         raise UnauthorizedError, "Authentication failed. Check your API keys."
       else
@@ -796,22 +802,40 @@ module Langfuse
       end
     end
 
+    # @param response [Faraday::Response] The HTTP response
+    # @return [void]
+    # @raise [ApiError] if the response body's `errors` array is non-empty
+    def raise_on_batch_errors(response)
+      errors = Array(parse_response_body(response)["errors"])
+      return if errors.empty?
+
+      messages = errors.filter_map { |e| e["message"] || e["error"] }
+      summary = messages.empty? ? "#{errors.size} event(s) rejected" : messages.join("; ")
+      raise ApiError, "Batch send failed: #{summary}"
+    end
+
     # Extract error message from response body
     #
     # @param response [Faraday::Response] The HTTP response
     # @return [String] The error message
     def extract_error_message(response)
-      body_hash = case response.body
-                  in Hash => h then h
-                  in String => s then begin
-                    JSON.parse(s)
-                  rescue StandardError
-                    {}
-                  end
-                  else {}
-                  end
+      body_hash = parse_response_body(response)
 
       %w[message error].filter_map { |key| body_hash[key] }.first || "Unknown error"
+    end
+
+    # @param response [Faraday::Response] The HTTP response
+    # @return [Hash] The parsed JSON body, or {} if absent/unparsable
+    def parse_response_body(response)
+      case response.body
+      in Hash => h then h
+      in String => s then begin
+        JSON.parse(s)
+      rescue StandardError
+        {}
+      end
+      else {}
+      end
     end
   end
 end

--- a/lib/langfuse/client.rb
+++ b/lib/langfuse/client.rb
@@ -347,7 +347,7 @@ module Langfuse
     #
     # @param name [String] Score name (required)
     # @param value [Numeric, Integer, String] Score value (type depends on data_type)
-    # @param id [String, nil] Score ID
+    # @param id [String, nil] Score ID; use a stable value as an idempotency key
     # @param trace_id [String, nil] Trace ID to associate with the score
     # @param session_id [String, nil] Session ID to associate with the score
     # @param observation_id [String, nil] Observation ID to associate with the score
@@ -396,12 +396,11 @@ module Langfuse
     end
     # rubocop:enable Metrics/ParameterLists
 
-    # Create a score event and send it immediately, bypassing the in-memory
-    # queue and the trace-sampling gate. See {ScoreClient#create!}.
+    # Create a score immediately through the Scores API. See {ScoreClient#create!}.
     #
     # @param name [String] Score name (required)
     # @param value [Numeric, Integer, String] Score value (type depends on data_type)
-    # @param id [String, nil] Score ID
+    # @param id [String, nil] Score ID; use a stable value as an idempotency key
     # @param trace_id [String, nil] Trace ID to associate with the score
     # @param session_id [String, nil] Session ID to associate with the score
     # @param observation_id [String, nil] Observation ID to associate with the score
@@ -411,13 +410,13 @@ module Langfuse
     # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
     # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
     # @param config_id [String, nil] Optional score config ID
-    # @return [void]
+    # @return [String] ID of the created score
     # @raise [ArgumentError] if validation fails
     # @raise [UnauthorizedError] if authentication fails
     # @raise [ApiError] if the API request fails
     #
-    # @example
-    #   client.create_score!(name: "quality", value: 0.85, trace_id: "abc123")
+    # @example Create a score with an idempotency key
+    #   client.create_score!(id: "feedback-abc123", name: "quality", value: 0.85, trace_id: "abc123")
     # rubocop:disable Metrics/ParameterLists
     def create_score!(name:, value:, id: nil, trace_id: nil, session_id: nil, observation_id: nil, comment: nil,
                       metadata: nil, environment: nil, data_type: :numeric, dataset_run_id: nil, config_id: nil)

--- a/lib/langfuse/client.rb
+++ b/lib/langfuse/client.rb
@@ -396,6 +396,48 @@ module Langfuse
     end
     # rubocop:enable Metrics/ParameterLists
 
+    # Create a score event and send it immediately, bypassing the in-memory
+    # queue and the trace-sampling gate. See {ScoreClient#create!}.
+    #
+    # @param name [String] Score name (required)
+    # @param value [Numeric, Integer, String] Score value (type depends on data_type)
+    # @param id [String, nil] Score ID
+    # @param trace_id [String, nil] Trace ID to associate with the score
+    # @param session_id [String, nil] Session ID to associate with the score
+    # @param observation_id [String, nil] Observation ID to associate with the score
+    # @param comment [String, nil] Optional comment
+    # @param metadata [Hash, nil] Optional metadata hash
+    # @param environment [String, nil] Optional environment
+    # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
+    # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
+    # @param config_id [String, nil] Optional score config ID
+    # @return [void]
+    # @raise [ArgumentError] if validation fails
+    # @raise [UnauthorizedError] if authentication fails
+    # @raise [ApiError] if the API request fails
+    #
+    # @example
+    #   client.create_score!(name: "quality", value: 0.85, trace_id: "abc123")
+    # rubocop:disable Metrics/ParameterLists
+    def create_score!(name:, value:, id: nil, trace_id: nil, session_id: nil, observation_id: nil, comment: nil,
+                      metadata: nil, environment: nil, data_type: :numeric, dataset_run_id: nil, config_id: nil)
+      @score_client.create!(
+        name: name,
+        value: value,
+        id: id,
+        trace_id: trace_id,
+        session_id: session_id,
+        observation_id: observation_id,
+        comment: comment,
+        metadata: metadata,
+        environment: environment,
+        data_type: data_type,
+        dataset_run_id: dataset_run_id,
+        config_id: config_id
+      )
+    end
+    # rubocop:enable Metrics/ParameterLists
+
     # Create a score for the currently active observation (from OTel span)
     #
     # Extracts observation_id and trace_id from the active OpenTelemetry span.

--- a/lib/langfuse/score_client.rb
+++ b/lib/langfuse/score_client.rb
@@ -56,7 +56,7 @@ module Langfuse
     #
     # @param name [String] Score name (required)
     # @param value [Numeric, Integer, String] Score value (type depends on data_type)
-    # @param id [String, nil] Score ID
+    # @param id [String, nil] Score ID; use a stable value as an idempotency key
     # @param trace_id [String, nil] Trace ID to associate with the score
     # @param session_id [String, nil] Session ID to associate with the score
     # @param observation_id [String, nil] Observation ID to associate with the score
@@ -87,7 +87,7 @@ module Langfuse
     # rubocop:disable Metrics/ParameterLists
     def create(name:, value:, id: nil, trace_id: nil, session_id: nil, observation_id: nil, comment: nil,
                metadata: nil, environment: nil, data_type: :numeric, dataset_run_id: nil, config_id: nil)
-      event = build_score_event(
+      score = build_score_body(
         name: name,
         value: value,
         id: id,
@@ -104,7 +104,7 @@ module Langfuse
 
       return unless enqueue_trace_linked_score?(trace_id)
 
-      @queue << event
+      @queue << build_score_event(score)
       flush if @queue.size >= config.batch_size
     rescue StandardError => e
       logger.error("Langfuse score creation failed: #{e.message}")
@@ -112,20 +112,19 @@ module Langfuse
     end
     # rubocop:enable Metrics/ParameterLists
 
-    # Create a score event and send it immediately, bypassing the in-memory
-    # queue and the trace-sampling gate.
+    # Create a score immediately through the Scores API.
     #
     # {#create} is fire-and-forget — it queues the event and reports nothing
     # about whether it was actually delivered, matching how this SDK's
     # tracing already works. That fits scoring inline from a still-open span
     # (see {#score_active_observation}/{#score_active_trace}), but not a
     # standalone verdict arriving out-of-band (e.g. user feedback landing in
-    # a request unrelated to the turn it's scoring), where the caller needs
-    # to know the outcome of this one delivery attempt in order to retry.
+    # a request unrelated to the turn it's scoring). Pass a stable +id+ when
+    # the caller may retry after an ambiguous network failure.
     #
     # @param name [String] Score name (required)
     # @param value [Numeric, Integer, String] Score value (type depends on data_type)
-    # @param id [String, nil] Score ID
+    # @param id [String, nil] Score ID; use a stable value as an idempotency key
     # @param trace_id [String, nil] Trace ID to associate with the score
     # @param session_id [String, nil] Session ID to associate with the score
     # @param observation_id [String, nil] Observation ID to associate with the score
@@ -135,17 +134,17 @@ module Langfuse
     # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
     # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
     # @param config_id [String, nil] Optional score config ID
-    # @return [void]
+    # @return [String] ID of the created score
     # @raise [ArgumentError] if validation fails
     # @raise [UnauthorizedError] if authentication fails
     # @raise [ApiError] if the API request fails
     #
-    # @example
-    #   score_client.create!(name: "quality", value: 0.85, trace_id: "abc123")
+    # @example Create a score with an idempotency key
+    #   score_client.create!(id: "feedback-abc123", name: "quality", value: 0.85, trace_id: "abc123")
     # rubocop:disable Metrics/ParameterLists
     def create!(name:, value:, id: nil, trace_id: nil, session_id: nil, observation_id: nil, comment: nil,
                 metadata: nil, environment: nil, data_type: :numeric, dataset_run_id: nil, config_id: nil)
-      event = build_score_event(
+      score = build_score_body(
         name: name,
         value: value,
         id: id,
@@ -160,7 +159,7 @@ module Langfuse
         config_id: config_id
       )
 
-      api_client.send_batch([event])
+      api_client.create_score(payload: score)
     end
     # rubocop:enable Metrics/ParameterLists
 
@@ -266,7 +265,7 @@ module Langfuse
 
     private
 
-    # Validates the given score inputs and builds the ingestion event hash for ingestion API
+    # Validate score inputs and build the canonical API body.
     #
     # @param name [String] Score name
     # @param value [Numeric, Integer, String] Raw score value (type depends on data_type)
@@ -280,37 +279,36 @@ module Langfuse
     # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
     # @param dataset_run_id [String, nil] Dataset run ID
     # @param config_id [String, nil] Score config ID
-    # @return [Hash] Event hash
+    # @return [Hash] Score attributes in API format
     # @raise [ArgumentError] if validation fails
     # rubocop:disable Metrics/ParameterLists
-    def build_score_event(name:, value:, id:, trace_id:, session_id:, observation_id:, comment:, metadata:,
-                          environment:, data_type:, dataset_run_id: nil, config_id: nil)
+    def build_score_body(name:, value:, id:, trace_id:, session_id:, observation_id:, comment:, metadata:,
+                         environment:, data_type:, dataset_run_id: nil, config_id: nil)
       validate_name(name)
       normalized_value = ScoreValue.normalize(value, data_type)
       data_type_str = Types::SCORE_DATA_TYPES[data_type] || raise(ArgumentError, "Invalid data_type: #{data_type}")
       validate_correction_subject!(data_type:, trace_id:, session_id:, dataset_run_id:, config_id:)
 
       {
-        id: SecureRandom.uuid,
-        type: "score-create",
-        timestamp: Time.now.utc.iso8601(3),
-        body: {
-          id: id || SecureRandom.uuid,
-          name: name,
-          value: normalized_value,
-          dataType: data_type_str,
-          traceId: trace_id,
-          sessionId: session_id,
-          observationId: observation_id,
-          comment: comment,
-          metadata: metadata,
-          environment: environment,
-          datasetRunId: dataset_run_id,
-          configId: config_id
-        }.compact
-      }
+        id: id || SecureRandom.uuid,
+        name: name,
+        value: normalized_value,
+        dataType: data_type_str,
+        traceId: trace_id,
+        sessionId: session_id,
+        observationId: observation_id,
+        comment: comment,
+        metadata: metadata,
+        environment: environment,
+        datasetRunId: dataset_run_id,
+        configId: config_id
+      }.compact
     end
     # rubocop:enable Metrics/ParameterLists
+
+    def build_score_event(score)
+      { id: SecureRandom.uuid, type: "score-create", timestamp: Time.now.utc.iso8601(3), body: score }
+    end
 
     def validate_correction_subject!(data_type:, trace_id:, session_id:, dataset_run_id:, config_id:)
       return unless data_type == :correction

--- a/lib/langfuse/score_client.rb
+++ b/lib/langfuse/score_client.rb
@@ -87,25 +87,80 @@ module Langfuse
     # rubocop:disable Metrics/ParameterLists
     def create(name:, value:, id: nil, trace_id: nil, session_id: nil, observation_id: nil, comment: nil,
                metadata: nil, environment: nil, data_type: :numeric, dataset_run_id: nil, config_id: nil)
-      validate_name(name)
-      normalized_value = ScoreValue.normalize(value, data_type)
-      data_type_str = Types::SCORE_DATA_TYPES[data_type] || raise(ArgumentError, "Invalid data_type: #{data_type}")
-      validate_correction_subject!(data_type:, trace_id:, session_id:, dataset_run_id:, config_id:)
+      event = build_score_event(
+        name: name,
+        value: value,
+        id: id,
+        trace_id: trace_id,
+        session_id: session_id,
+        observation_id: observation_id,
+        comment: comment,
+        metadata: metadata,
+        environment: environment,
+        data_type: data_type,
+        dataset_run_id: dataset_run_id,
+        config_id: config_id
+      )
 
       return unless enqueue_trace_linked_score?(trace_id)
-
-      event = build_score_event(
-        name: name, value: normalized_value, id: id, trace_id: trace_id,
-        session_id: session_id, observation_id: observation_id, comment: comment,
-        metadata: metadata, environment: environment, data_type: data_type_str,
-        dataset_run_id: dataset_run_id, config_id: config_id
-      )
 
       @queue << event
       flush if @queue.size >= config.batch_size
     rescue StandardError => e
       logger.error("Langfuse score creation failed: #{e.message}")
       raise
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    # Create a score event and send it immediately, bypassing the in-memory
+    # queue and the trace-sampling gate.
+    #
+    # {#create} is fire-and-forget — it queues the event and reports nothing
+    # about whether it was actually delivered, matching how this SDK's
+    # tracing already works. That fits scoring inline from a still-open span
+    # (see {#score_active_observation}/{#score_active_trace}), but not a
+    # standalone verdict arriving out-of-band (e.g. user feedback landing in
+    # a request unrelated to the turn it's scoring), where the caller needs
+    # to know the outcome of this one delivery attempt in order to retry.
+    #
+    # @param name [String] Score name (required)
+    # @param value [Numeric, Integer, String] Score value (type depends on data_type)
+    # @param id [String, nil] Score ID
+    # @param trace_id [String, nil] Trace ID to associate with the score
+    # @param session_id [String, nil] Session ID to associate with the score
+    # @param observation_id [String, nil] Observation ID to associate with the score
+    # @param comment [String, nil] Optional comment
+    # @param metadata [Hash, nil] Optional metadata hash
+    # @param environment [String, nil] Optional environment
+    # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
+    # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
+    # @param config_id [String, nil] Optional score config ID
+    # @return [void]
+    # @raise [ArgumentError] if validation fails
+    # @raise [UnauthorizedError] if authentication fails
+    # @raise [ApiError] if the API request fails
+    #
+    # @example
+    #   score_client.create!(name: "quality", value: 0.85, trace_id: "abc123")
+    # rubocop:disable Metrics/ParameterLists
+    def create!(name:, value:, id: nil, trace_id: nil, session_id: nil, observation_id: nil, comment: nil,
+                metadata: nil, environment: nil, data_type: :numeric, dataset_run_id: nil, config_id: nil)
+      event = build_score_event(
+        name: name,
+        value: value,
+        id: id,
+        trace_id: trace_id,
+        session_id: session_id,
+        observation_id: observation_id,
+        comment: comment,
+        metadata: metadata,
+        environment: environment,
+        data_type: data_type,
+        dataset_run_id: dataset_run_id,
+        config_id: config_id
+      )
+
+      api_client.send_batch([event])
     end
     # rubocop:enable Metrics/ParameterLists
 
@@ -211,10 +266,10 @@ module Langfuse
 
     private
 
-    # Build a score event hash for ingestion API
+    # Validates the given score inputs and builds the ingestion event hash for ingestion API
     #
     # @param name [String] Score name
-    # @param value [Object] Normalized score value
+    # @param value [Numeric, Integer, String] Raw score value (type depends on data_type)
     # @param id [String, nil] Score ID
     # @param trace_id [String, nil] Trace ID
     # @param session_id [String, nil] Session ID
@@ -222,30 +277,37 @@ module Langfuse
     # @param comment [String, nil] Comment
     # @param metadata [Hash, nil] Metadata
     # @param environment [String, nil] Environment
-    # @param data_type [String] API score data type string
+    # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
+    # @param dataset_run_id [String, nil] Dataset run ID
+    # @param config_id [String, nil] Score config ID
     # @return [Hash] Event hash
+    # @raise [ArgumentError] if validation fails
     # rubocop:disable Metrics/ParameterLists
     def build_score_event(name:, value:, id:, trace_id:, session_id:, observation_id:, comment:, metadata:,
                           environment:, data_type:, dataset_run_id: nil, config_id: nil)
-      body = {
-        id: id || SecureRandom.uuid,
-        name: name,
-        value: value,
-        dataType: data_type,
-        traceId: trace_id,
-        sessionId: session_id,
-        observationId: observation_id,
-        comment: comment,
-        metadata: metadata,
-        environment: environment,
-        datasetRunId: dataset_run_id,
-        configId: config_id
-      }.compact
+      validate_name(name)
+      normalized_value = ScoreValue.normalize(value, data_type)
+      data_type_str = Types::SCORE_DATA_TYPES[data_type] || raise(ArgumentError, "Invalid data_type: #{data_type}")
+      validate_correction_subject!(data_type:, trace_id:, session_id:, dataset_run_id:, config_id:)
+
       {
         id: SecureRandom.uuid,
         type: "score-create",
         timestamp: Time.now.utc.iso8601(3),
-        body: body
+        body: {
+          id: id || SecureRandom.uuid,
+          name: name,
+          value: normalized_value,
+          dataType: data_type_str,
+          traceId: trace_id,
+          sessionId: session_id,
+          observationId: observation_id,
+          comment: comment,
+          metadata: metadata,
+          environment: environment,
+          datasetRunId: dataset_run_id,
+          configId: config_id
+        }.compact
       }
     end
     # rubocop:enable Metrics/ParameterLists

--- a/spec/langfuse/api_client_spec.rb
+++ b/spec/langfuse/api_client_spec.rb
@@ -1337,6 +1337,83 @@ RSpec.describe Langfuse::ApiClient do
 
         expect { api_client.send_batch(events) }.not_to raise_error
       end
+
+      it "handles a 207 response whose body lists no errors" do
+        stub_request(:post, "#{base_url}/api/public/ingestion")
+          .to_return(
+            status: 207,
+            body: { successes: [{ id: events.first[:id], status: 201 }], errors: [] }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        expect { api_client.send_batch(events) }.not_to raise_error
+      end
+    end
+
+    context "with a 207 response listing rejected events" do
+      # The ingestion endpoint never returns a 4xx for rejected events — per its
+      # own spec, "input errors" surface as 200/207 with entries in the body's
+      # `errors` array instead, so that array is the only real signal.
+      it "raises ApiError even though the HTTP status is 207" do
+        stub_request(:post, "#{base_url}/api/public/ingestion")
+          .to_return(
+            status: 207,
+            body: {
+              successes: [],
+              errors: [{ id: events.first[:id], status: 400, message: "name is required" }]
+            }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        expect do
+          api_client.send_batch(events)
+        end.to raise_error(Langfuse::ApiError, /name is required/)
+      end
+
+      it "raises ApiError for a 200 status whose body still lists errors" do
+        stub_request(:post, "#{base_url}/api/public/ingestion")
+          .to_return(
+            status: 200,
+            body: { successes: [], errors: [{ id: events.first[:id], status: 400, message: "boom" }] }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        expect do
+          api_client.send_batch(events)
+        end.to raise_error(Langfuse::ApiError, /boom/)
+      end
+
+      it "joins multiple error messages" do
+        stub_request(:post, "#{base_url}/api/public/ingestion")
+          .to_return(
+            status: 207,
+            body: {
+              successes: [],
+              errors: [
+                { id: events.first[:id], status: 400, message: "name is required" },
+                { id: events.last[:id], status: 400, message: "value is required" }
+              ]
+            }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        expect do
+          api_client.send_batch(events)
+        end.to raise_error(Langfuse::ApiError, "Batch send failed: name is required; value is required")
+      end
+
+      it "falls back to a count when an error entry has no message or error field" do
+        stub_request(:post, "#{base_url}/api/public/ingestion")
+          .to_return(
+            status: 207,
+            body: { successes: [], errors: [{ id: events.first[:id], status: 400 }] }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        expect do
+          api_client.send_batch(events)
+        end.to raise_error(Langfuse::ApiError, "Batch send failed: 1 event(s) rejected")
+      end
     end
 
     context "with validation errors" do

--- a/spec/langfuse/api_client_spec.rb
+++ b/spec/langfuse/api_client_spec.rb
@@ -1280,6 +1280,61 @@ RSpec.describe Langfuse::ApiClient do
     end
   end
 
+  describe "#create_score" do
+    let(:payload) do
+      {
+        id: "score-123",
+        name: "quality",
+        value: 0.85,
+        dataType: "NUMERIC",
+        traceId: "trace-123"
+      }
+    end
+
+    it "creates the score through the Scores API and returns its ID" do
+      stub_request(:post, "#{base_url}/api/public/scores")
+        .with(body: payload.to_json)
+        .to_return(
+          status: 200,
+          body: { id: "score-123" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      expect(api_client.create_score(payload: payload)).to eq("score-123")
+    end
+
+    it "raises ApiError when the response omits the score ID" do
+      stub_request(:post, "#{base_url}/api/public/scores")
+        .to_return(status: 200, body: {}.to_json, headers: { "Content-Type" => "application/json" })
+
+      expect do
+        api_client.create_score(payload: payload)
+      end.to raise_error(Langfuse::ApiError, "Score creation response did not include an id")
+    end
+
+    it "raises ApiError when the response contains an invalid score ID" do
+      stub_request(:post, "#{base_url}/api/public/scores")
+        .to_return(status: 200, body: { id: nil }.to_json, headers: { "Content-Type" => "application/json" })
+
+      expect do
+        api_client.create_score(payload: payload)
+      end.to raise_error(Langfuse::ApiError, "Score creation response did not include an id")
+    end
+
+    it "raises ApiError for invalid score data" do
+      stub_request(:post, "#{base_url}/api/public/scores")
+        .to_return(
+          status: 400,
+          body: { message: "Invalid request data" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      expect do
+        api_client.create_score(payload: payload)
+      end.to raise_error(Langfuse::ApiError, "API request failed (400): Invalid request data")
+    end
+  end
+
   describe "#send_batch" do
     let(:events) do
       [

--- a/spec/langfuse/client_spec.rb
+++ b/spec/langfuse/client_spec.rb
@@ -1686,6 +1686,44 @@ RSpec.describe Langfuse::Client do
     end
   end
 
+  describe "#create_score!" do
+    let(:client) { described_class.new(valid_config) }
+
+    before do
+      stub_request(:post, "https://cloud.langfuse.com/api/public/ingestion")
+        .to_return(status: 200, body: "", headers: {})
+    end
+
+    it "delegates to score_client#create!" do
+      score_client = client.instance_variable_get(:@score_client)
+      expect(score_client).to receive(:create!).with(
+        name: "quality",
+        value: 0.85,
+        id: nil,
+        trace_id: "abc123",
+        session_id: nil,
+        observation_id: nil,
+        comment: nil,
+        metadata: nil,
+        environment: nil,
+        data_type: :numeric,
+        dataset_run_id: nil,
+        config_id: nil
+      )
+
+      client.create_score!(name: "quality", value: 0.85, trace_id: "abc123")
+    end
+
+    it "propagates errors from score_client#create! instead of swallowing them" do
+      score_client = client.instance_variable_get(:@score_client)
+      allow(score_client).to receive(:create!).and_raise(Langfuse::ApiError, "Batch send failed (500): boom")
+
+      expect do
+        client.create_score!(name: "quality", value: 0.85, trace_id: "abc123")
+      end.to raise_error(Langfuse::ApiError, "Batch send failed (500): boom")
+    end
+  end
+
   describe "#score_active_observation" do
     let(:client) { described_class.new(valid_config) }
     let(:tracer) { OpenTelemetry.tracer_provider.tracer("test") }

--- a/spec/langfuse/client_spec.rb
+++ b/spec/langfuse/client_spec.rb
@@ -1689,12 +1689,7 @@ RSpec.describe Langfuse::Client do
   describe "#create_score!" do
     let(:client) { described_class.new(valid_config) }
 
-    before do
-      stub_request(:post, "https://cloud.langfuse.com/api/public/ingestion")
-        .to_return(status: 200, body: "", headers: {})
-    end
-
-    it "delegates to score_client#create!" do
+    it "delegates to score_client#create! and returns the score ID" do
       score_client = client.instance_variable_get(:@score_client)
       expect(score_client).to receive(:create!).with(
         name: "quality",
@@ -1709,18 +1704,45 @@ RSpec.describe Langfuse::Client do
         data_type: :numeric,
         dataset_run_id: nil,
         config_id: nil
+      ).and_return("score-123")
+
+      expect(client.create_score!(name: "quality", value: 0.85, trace_id: "abc123")).to eq("score-123")
+    end
+
+    it "creates a correction score through the direct Scores API" do
+      payload = {
+        id: "score-123",
+        name: "output",
+        value: "Synthetic corrected output",
+        dataType: "CORRECTION",
+        traceId: "abcdef1234567890abcdef1234567890"
+      }
+      stub_request(:post, "https://cloud.langfuse.com/api/public/scores")
+        .with(body: payload.to_json)
+        .to_return(
+          status: 200,
+          body: { id: "score-123" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      result = client.create_score!(
+        id: "score-123",
+        name: "output",
+        value: "Synthetic corrected output",
+        trace_id: "abcdef1234567890abcdef1234567890",
+        data_type: :correction
       )
 
-      client.create_score!(name: "quality", value: 0.85, trace_id: "abc123")
+      expect(result).to eq("score-123")
     end
 
     it "propagates errors from score_client#create! instead of swallowing them" do
       score_client = client.instance_variable_get(:@score_client)
-      allow(score_client).to receive(:create!).and_raise(Langfuse::ApiError, "Batch send failed (500): boom")
+      allow(score_client).to receive(:create!).and_raise(Langfuse::ApiError, "API request failed (500): boom")
 
       expect do
         client.create_score!(name: "quality", value: 0.85, trace_id: "abc123")
-      end.to raise_error(Langfuse::ApiError, "Batch send failed (500): boom")
+      end.to raise_error(Langfuse::ApiError, "API request failed (500): boom")
     end
   end
 

--- a/spec/langfuse/score_client_spec.rb
+++ b/spec/langfuse/score_client_spec.rb
@@ -546,22 +546,35 @@ RSpec.describe Langfuse::ScoreClient do
   end
 
   describe "#create!" do
-    it "sends the event immediately without queueing it" do
-      expect(api_client).to receive(:send_batch).with(array_including(
-                                                        hash_including(
-                                                          type: "score-create",
-                                                          body: hash_including(
-                                                            name: "quality",
-                                                            value: 0.85,
-                                                            dataType: "NUMERIC",
-                                                            traceId: "abc123"
-                                                          )
-                                                        )
-                                                      ))
+    it "creates the score directly, returns its ID, and leaves the queue empty" do
+      expect(api_client).to receive(:create_score).with(
+        payload: hash_including(
+          id: "score-123",
+          name: "quality",
+          value: 0.85,
+          dataType: "NUMERIC",
+          traceId: "abc123"
+        )
+      ).and_return("score-123")
 
-      score_client.create!(name: "quality", value: 0.85, trace_id: "abc123", data_type: :numeric)
+      result = score_client.create!(
+        id: "score-123",
+        name: "quality",
+        value: 0.85,
+        trace_id: "abc123",
+        data_type: :numeric
+      )
 
+      expect(result).to eq("score-123")
       expect(score_client.instance_variable_get(:@queue)).to be_empty
+    end
+
+    it "returns an automatically generated score ID" do
+      allow(api_client).to receive(:create_score) { |payload:| payload.fetch(:id) }
+
+      result = score_client.create!(name: "quality", value: 0.85, trace_id: "abc123")
+
+      expect(result).to match(/\A[0-9a-f-]{36}\z/)
     end
 
     it "bypasses sampling — delivers even when the configured sample_rate would drop it" do
@@ -576,16 +589,16 @@ RSpec.describe Langfuse::ScoreClient do
       strict_api_client = instance_double(Langfuse::ApiClient)
       strict_client = described_class.new(api_client: strict_api_client, config: strict_config)
 
-      expect(strict_api_client).to receive(:send_batch)
+      expect(strict_api_client).to receive(:create_score)
       strict_client.create!(name: "quality", value: 1.0, trace_id: "abcdef1234567890abcdef1234567890")
     end
 
     it "raises the ApiClient error instead of swallowing it" do
-      expect(api_client).to receive(:send_batch).and_raise(Langfuse::ApiError, "Batch send failed (500): boom")
+      expect(api_client).to receive(:create_score).and_raise(Langfuse::ApiError, "API request failed (500): boom")
 
       expect do
         score_client.create!(name: "quality", value: 0.85)
-      end.to raise_error(Langfuse::ApiError, "Batch send failed (500): boom")
+      end.to raise_error(Langfuse::ApiError, "API request failed (500): boom")
     end
 
     it "raises ArgumentError for invalid input, same as #create" do

--- a/spec/langfuse/score_client_spec.rb
+++ b/spec/langfuse/score_client_spec.rb
@@ -545,6 +545,56 @@ RSpec.describe Langfuse::ScoreClient do
     end
   end
 
+  describe "#create!" do
+    it "sends the event immediately without queueing it" do
+      expect(api_client).to receive(:send_batch).with(array_including(
+                                                        hash_including(
+                                                          type: "score-create",
+                                                          body: hash_including(
+                                                            name: "quality",
+                                                            value: 0.85,
+                                                            dataType: "NUMERIC",
+                                                            traceId: "abc123"
+                                                          )
+                                                        )
+                                                      ))
+
+      score_client.create!(name: "quality", value: 0.85, trace_id: "abc123", data_type: :numeric)
+
+      expect(score_client.instance_variable_get(:@queue)).to be_empty
+    end
+
+    it "bypasses sampling — delivers even when the configured sample_rate would drop it" do
+      strict_config = Langfuse::Config.new do |c|
+        c.public_key = "pk_test"
+        c.secret_key = "sk_test"
+        c.base_url = "https://cloud.langfuse.com"
+        c.sample_rate = 0.0
+        c.flush_interval = 0
+        c.logger = Logger.new(StringIO.new)
+      end
+      strict_api_client = instance_double(Langfuse::ApiClient)
+      strict_client = described_class.new(api_client: strict_api_client, config: strict_config)
+
+      expect(strict_api_client).to receive(:send_batch)
+      strict_client.create!(name: "quality", value: 1.0, trace_id: "abcdef1234567890abcdef1234567890")
+    end
+
+    it "raises the ApiClient error instead of swallowing it" do
+      expect(api_client).to receive(:send_batch).and_raise(Langfuse::ApiError, "Batch send failed (500): boom")
+
+      expect do
+        score_client.create!(name: "quality", value: 0.85)
+      end.to raise_error(Langfuse::ApiError, "Batch send failed (500): boom")
+    end
+
+    it "raises ArgumentError for invalid input, same as #create" do
+      expect do
+        score_client.create!(name: nil, value: 0.85)
+      end.to raise_error(ArgumentError, "name is required")
+    end
+  end
+
   describe "#score_active_observation" do
     let(:tracer) { OpenTelemetry.tracer_provider.tracer("test") }
     let(:span) { tracer.start_span("test-span") }

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -258,6 +258,53 @@ RSpec.describe Langfuse do
     end
   end
 
+  describe ".create_score!" do
+    it "forwards the full score kwarg set to client" do
+      client = instance_double(Langfuse::Client)
+      allow(described_class).to receive(:client).and_return(client)
+
+      expect(client).to receive(:create_score!).with(
+        name: "quality",
+        value: 0.85,
+        id: "score-123",
+        trace_id: "trace-123",
+        session_id: "session-123",
+        observation_id: "observation-123",
+        comment: "High quality",
+        metadata: { source: "manual" },
+        environment: "production",
+        data_type: :numeric,
+        dataset_run_id: "run-123",
+        config_id: "cfg-123"
+      )
+
+      described_class.create_score!(
+        name: "quality",
+        value: 0.85,
+        id: "score-123",
+        trace_id: "trace-123",
+        session_id: "session-123",
+        observation_id: "observation-123",
+        comment: "High quality",
+        metadata: { source: "manual" },
+        environment: "production",
+        data_type: :numeric,
+        dataset_run_id: "run-123",
+        config_id: "cfg-123"
+      )
+    end
+
+    it "propagates errors from client#create_score! instead of swallowing them" do
+      client = instance_double(Langfuse::Client)
+      allow(described_class).to receive(:client).and_return(client)
+      allow(client).to receive(:create_score!).and_raise(Langfuse::ApiError, "Batch send failed (500): boom")
+
+      expect do
+        described_class.create_score!(name: "quality", value: 0.85, trace_id: "trace-123")
+      end.to raise_error(Langfuse::ApiError, "Batch send failed (500): boom")
+    end
+  end
+
   describe ".create_trace_id" do
     it "delegates to TraceId.create with no seed" do
       trace_id = described_class.create_trace_id

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -276,9 +276,9 @@ RSpec.describe Langfuse do
         data_type: :numeric,
         dataset_run_id: "run-123",
         config_id: "cfg-123"
-      )
+      ).and_return("score-123")
 
-      described_class.create_score!(
+      result = described_class.create_score!(
         name: "quality",
         value: 0.85,
         id: "score-123",
@@ -292,16 +292,18 @@ RSpec.describe Langfuse do
         dataset_run_id: "run-123",
         config_id: "cfg-123"
       )
+
+      expect(result).to eq("score-123")
     end
 
     it "propagates errors from client#create_score! instead of swallowing them" do
       client = instance_double(Langfuse::Client)
       allow(described_class).to receive(:client).and_return(client)
-      allow(client).to receive(:create_score!).and_raise(Langfuse::ApiError, "Batch send failed (500): boom")
+      allow(client).to receive(:create_score!).and_raise(Langfuse::ApiError, "API request failed (500): boom")
 
       expect do
         described_class.create_score!(name: "quality", value: 0.85, trace_id: "trace-123")
-      end.to raise_error(Langfuse::ApiError, "Batch send failed (500): boom")
+      end.to raise_error(Langfuse::ApiError, "API request failed (500): boom")
     end
   end
 


### PR DESCRIPTION
#### `TL;DR`
Adds `ScoreClient#create!` / `Client#create_score!` / `Langfuse.create_score!` for synchronous, exception-raising score creation, and fixes a latent bug where the SDK silently treated ingestion-rejected batch events as delivered.

#### `Why`
`create_score` is fire-and-forget: it queues the event and reports nothing about whether it was actually delivered, which matches how this SDK's tracing already works and is the right default for scoring inline from a still-open span. But it's the wrong shape for a standalone score arriving out-of-band — e.g. user feedback landing in a request unrelated to the turn it's scoring — where the caller needs to know whether delivery succeeded in order to decide whether to retry. `create_score!` bypasses the in-memory queue and the trace-sampling gate, sends immediately, and raises (`UnauthorizedError`/`ApiError`) on failure.

While building that, found and fixed a bug in `handle_batch_response` that affects the whole SDK, not just this new path: Langfuse's ingestion endpoint never returns a 4xx for rejected events — per the endpoint's own spec, "input errors" surface as a 200-series/207 response whose body lists them in an `errors` array instead. That array is the only real per-event success/failure signal; HTTP status alone can't distinguish a fully accepted batch from a fully rejected one. `handle_batch_response` previously treated every 200/201/204/207 as unconditional success without ever parsing that array, so a rejected event (e.g. failed validation) was silently reported as delivered. This matters more once `create_score!` exists, since callers are now relying on "no exception" to mean "delivered" — but it was already wrong for every batch send before this PR.

#### `Checklist`
- [ ] Has label
- [ ] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)

Closes #

#### `What changed`
- `Langfuse::ScoreClient#create!`: new synchronous variant of `#create` — builds the same event, then calls `api_client.send_batch([event])` directly instead of enqueueing.
- `Langfuse::Client#create_score!` and `Langfuse.create_score!`: flat-API forwarding wrappers, matching this SDK's no-nested-objects convention.
- Extracted the shared validation/normalization/event-building logic (name validation, value normalization, `data_type` lookup) out of `#create` and into `#build_score_event` itself, so `#create!` doesn't duplicate it.
- `Langfuse::ApiClient#handle_batch_response`: now calls `raise_on_batch_errors`, which parses the response body's `errors` array and raises `ApiError` summarizing the rejected event(s) if it's non-empty. Extracted `parse_response_body` (previously inlined in `extract_error_message`) since both now need it.
- `docs/API_REFERENCE.md`: documented `create_score!`.
- `CHANGELOG.md`: noted under `[Unreleased]`.

#### `Validation`

```
bundle exec rspec
# 1355 examples, 0 failures
# Line Coverage: 96.86% (2376 / 2453)

bundle exec rubocop
# 79 files inspected, no offenses detected
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes score delivery semantics and makes batched ingestion fail loudly on partial rejections, which may surface errors that were previously silent across all `send_batch` callers.
> 
> **Overview**
> Adds **`create!` / `create_score!` / `Langfuse.create_score!`** for synchronous score creation via `POST /api/public/scores`, returning the score ID and raising on API failure. These paths skip the ingestion queue and trace sampling; existing **`create` / `create_score`** stay fire-and-forget.
> 
> **`ScoreClient`** now builds scores through shared **`build_score_body`** for both queued and direct creation. Score **`id`** is documented as a stable idempotency key.
> 
> **`ApiClient#handle_batch_response`** now inspects the response body’s **`errors`** array on 200/207 and raises **`ApiError`** when events are rejected, instead of treating those statuses as unconditional success. **`ApiClient#create_score`** is added for the direct scores endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b28e874d562570fba1ca171c904cdffa234ff61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->