### PR TITLE
fix(scoring): inherit configured environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implicit observations warn once and use a no-op tracer when tracing configuration is invalid. Explicit `Langfuse.tracer_provider` access still raises `ConfigurationError`.
 
 ### Fixed
+- Score creation now uses the configured client environment when a score does not provide an environment override.
 - Configuration validation now reports invalid numeric types, stale cache settings, and tracing callables as `ConfigurationError`.
 - Tracing validates batching and sampling settings before it creates an OpenTelemetry span processor.
 - Explicit Rails cache configuration now fails validation when `Rails.cache` is unavailable. Previously only the presence of `Rails.cache` as a method was checked, so a client built before Rails ran `initialize_cache` failed later on the first cache read instead.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1046,6 +1046,10 @@ create_score(name:, value:, id: nil, trace_id: nil, session_id: nil, observation
              dataset_run_id: nil, config_id: nil)
 ```
 
+When `environment` is omitted, the score uses the client-level environment from
+`Config#environment`. A score-level value overrides the configured environment.
+If neither value is set, Langfuse uses its `default` environment.
+
 **Parameters:**
 
 | Parameter        | Type                   | Required | Description                               |
@@ -1058,7 +1062,7 @@ create_score(name:, value:, id: nil, trace_id: nil, session_id: nil, observation
 | `observation_id` | String                 | No       | Observation ID to score                   |
 | `comment`        | String                 | No       | Score comment                             |
 | `metadata`       | Hash                   | No       | Additional metadata                       |
-| `environment`    | String                 | No       | Environment tag for the score             |
+| `environment`    | String                 | No       | Per-score override for the configured environment |
 | `data_type`      | Symbol                 | No       | `:numeric`, `:boolean`, `:categorical`, `:text`, or `:correction` |
 | `dataset_run_id` | String                 | No       | Dataset run ID to associate with          |
 | `config_id`      | String                 | No       | Score config ID                           |

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -246,7 +246,7 @@ module Langfuse
     # @param observation_id [String, nil] Observation ID to associate with the score
     # @param comment [String, nil] Optional comment
     # @param metadata [Hash, nil] Optional metadata hash
-    # @param environment [String, nil] Optional environment
+    # @param environment [String, nil] Optional per-score environment override
     # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
     # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
     # @param config_id [String, nil] Optional score config ID
@@ -291,7 +291,7 @@ module Langfuse
     # @param observation_id [String, nil] Observation ID to associate with the score
     # @param comment [String, nil] Optional comment
     # @param metadata [Hash, nil] Optional metadata hash
-    # @param environment [String, nil] Optional environment
+    # @param environment [String, nil] Optional per-score environment override
     # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
     # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
     # @param config_id [String, nil] Optional score config ID

--- a/lib/langfuse/client.rb
+++ b/lib/langfuse/client.rb
@@ -359,7 +359,7 @@ module Langfuse
     # @param observation_id [String, nil] Observation ID to associate with the score
     # @param comment [String, nil] Optional comment
     # @param metadata [Hash, nil] Optional metadata hash
-    # @param environment [String, nil] Optional environment
+    # @param environment [String, nil] Optional per-score environment override
     # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
     # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
     # @param config_id [String, nil] Optional score config ID
@@ -412,7 +412,7 @@ module Langfuse
     # @param observation_id [String, nil] Observation ID to associate with the score
     # @param comment [String, nil] Optional comment
     # @param metadata [Hash, nil] Optional metadata hash
-    # @param environment [String, nil] Optional environment
+    # @param environment [String, nil] Optional per-score environment override
     # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
     # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
     # @param config_id [String, nil] Optional score config ID

--- a/lib/langfuse/score_client.rb
+++ b/lib/langfuse/score_client.rb
@@ -62,7 +62,7 @@ module Langfuse
     # @param observation_id [String, nil] Observation ID to associate with the score
     # @param comment [String, nil] Optional comment
     # @param metadata [Hash, nil] Optional metadata hash
-    # @param environment [String, nil] Optional environment
+    # @param environment [String, nil] Optional per-score environment override
     # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
     # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
     # @param config_id [String, nil] Optional score config ID
@@ -130,7 +130,7 @@ module Langfuse
     # @param observation_id [String, nil] Observation ID to associate with the score
     # @param comment [String, nil] Optional comment
     # @param metadata [Hash, nil] Optional metadata hash
-    # @param environment [String, nil] Optional environment
+    # @param environment [String, nil] Optional per-score environment override
     # @param data_type [Symbol] Data type (:numeric, :boolean, :categorical, :text, :correction)
     # @param dataset_run_id [String, nil] Optional dataset run ID to associate with the score
     # @param config_id [String, nil] Optional score config ID
@@ -299,7 +299,7 @@ module Langfuse
         observationId: observation_id,
         comment: comment,
         metadata: metadata,
-        environment: environment,
+        environment: environment || config.environment,
         datasetRunId: dataset_run_id,
         configId: config_id
       }.compact

--- a/spec/langfuse/client_spec.rb
+++ b/spec/langfuse/client_spec.rb
@@ -1694,6 +1694,24 @@ RSpec.describe Langfuse::Client do
         data_type: :boolean
       )
     end
+
+    it "sends the configured environment through the ingestion API" do
+      valid_config.environment = "staging"
+      configured_client = described_class.new(valid_config)
+      request = stub_request(:post, "https://cloud.langfuse.com/api/public/ingestion")
+      request.with do |incoming_request|
+        body = JSON.parse(incoming_request.body)
+        body.dig("batch", 0, "body", "environment") == "staging"
+      end
+      request.to_return(status: 200, body: "", headers: {})
+
+      configured_client.create_score(name: "quality", value: 0.85, session_id: "session-123")
+      configured_client.flush_scores
+
+      expect(request).to have_been_requested.once
+    ensure
+      configured_client&.shutdown
+    end
   end
 
   describe "#create_score!" do
@@ -1744,6 +1762,24 @@ RSpec.describe Langfuse::Client do
       )
 
       expect(result).to eq("score-123")
+    end
+
+    it "sends the configured environment through the direct Scores API" do
+      valid_config.environment = "staging"
+      configured_client = described_class.new(valid_config)
+      stub_request(:post, "https://cloud.langfuse.com/api/public/scores")
+        .with(body: hash_including(environment: "staging"))
+        .to_return(
+          status: 200,
+          body: { id: "score-123" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      result = configured_client.create_score!(id: "score-123", name: "quality", value: 0.85)
+
+      expect(result).to eq("score-123")
+    ensure
+      configured_client&.shutdown
     end
 
     it "propagates errors from score_client#create! instead of swallowing them" do

--- a/spec/langfuse/score_client_spec.rb
+++ b/spec/langfuse/score_client_spec.rb
@@ -150,6 +150,30 @@ RSpec.describe Langfuse::ScoreClient do
         score_client.flush
       end
 
+      it "uses the configured environment when the score omits an override" do
+        config.environment = "staging"
+        expect(api_client).to receive(:send_batch).with(array_including(
+                                                          hash_including(
+                                                            body: hash_including(environment: "staging")
+                                                          )
+                                                        ))
+
+        score_client.create(name: "quality", value: 0.85)
+        score_client.flush
+      end
+
+      it "prefers the score environment over the configured environment" do
+        config.environment = "staging"
+        expect(api_client).to receive(:send_batch).with(array_including(
+                                                          hash_including(
+                                                            body: hash_including(environment: "production")
+                                                          )
+                                                        ))
+
+        score_client.create(name: "quality", value: 0.85, environment: "production")
+        score_client.flush
+      end
+
       it "includes dataset_run_id when provided" do
         expect(api_client).to receive(:send_batch).with(array_including(
                                                           hash_including(
@@ -172,9 +196,10 @@ RSpec.describe Langfuse::ScoreClient do
         score_client.flush
       end
 
-      it "omits dataset_run_id and config_id when nil" do
+      it "omits optional attributes when they and the configured environment are nil" do
         expect(api_client).to receive(:send_batch) do |events|
           body = events.first[:body]
+          expect(body).not_to have_key(:environment)
           expect(body).not_to have_key(:datasetRunId)
           expect(body).not_to have_key(:configId)
         end
@@ -567,6 +592,24 @@ RSpec.describe Langfuse::ScoreClient do
 
       expect(result).to eq("score-123")
       expect(score_client.instance_variable_get(:@queue)).to be_empty
+    end
+
+    it "uses the configured environment when the score omits an override" do
+      config.environment = "staging"
+      expect(api_client).to receive(:create_score).with(
+        payload: hash_including(environment: "staging")
+      ).and_return("score-123")
+
+      score_client.create!(id: "score-123", name: "quality", value: 0.85)
+    end
+
+    it "prefers the score environment over the configured environment" do
+      config.environment = "staging"
+      expect(api_client).to receive(:create_score).with(
+        payload: hash_including(environment: "production")
+      ).and_return("score-123")
+
+      score_client.create!(id: "score-123", name: "quality", value: 0.85, environment: "production")
     end
 
     it "returns an automatically generated score ID" do


### PR DESCRIPTION
#### `TL;DR`
<!-- One sentence -->

Scores without a per-score environment now inherit the configured client environment.

##### Change diagram

```mermaid
flowchart TB
    accTitle: Score environment inheritance
    accDescr: Direct and batched scores use an explicit environment, then the configured environment, then the Langfuse default.

    subgraph Before
        B1["Score omits environment"] --> B2["Payload omits environment"]
        B2 --> B3["Langfuse uses default"]
    end

    subgraph After
        A1["Direct or batched score"] --> A2{"Score override?"}
        A2 -->|Yes| A3["Use score environment"]
        A2 -->|No| A4{"Configured environment?"}
        A4 -->|Yes| A5["Use configured environment"]
        A4 -->|No| A6["Langfuse uses default"]
    end
```

#### `Why`
<!-- Motivation/context for this change -->

Configured environments separate score analytics across development, staging, and production. Scores previously ignored the client environment unless each call repeated the value. Langfuse stored those scores under `default`.

#### `Checklist`
- [x] Has label
- [ ] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)

Closes #

> [!NOTE]
> **Kade's words:** "make sure to verify e2e using sdk and langfuse cli (creds in .env)"

## Verification

I ran the complete Ruby suite locally. All 1,576 examples passed. Line coverage was 97.25%.

I ran RuboCop across 96 files. RuboCop reported no offenses. I also checked the pull request diff for whitespace errors.

I created four synthetic scores through the local Ruby SDK with credentials from `.env`. The direct and batched paths each covered an explicit environment and the configured client environment. Langfuse accepted all four scores.

I read the same records through Langfuse CLI 1.0.0 and the Scores v3 API. Each explicit score used `score-exp-12d8c6a2`. Each inherited score used `score-cfg-12d8c6a2`. Environment filters returned the expected two records in each group.

I reviewed the Mermaid source but did not preview the rendered diagram in GitHub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow scoring payload change with tests and docs; only affects which environment tag is sent when callers relied on client config without per-score overrides.
> 
> **Overview**
> **Fixes score environment tagging** so scores that omit `environment` inherit **`Config#environment`** instead of leaving the field out and landing in Langfuse’s default.
> 
> The change is in **`ScoreClient#build_score_body`**: the payload uses `environment || config.environment`, then **`.compact`** still drops `environment` when both are unset. A per-score **`environment:`** override continues to take precedence. This applies to **batched** `create_score` / ingestion and **synchronous** `create_score!`.
> 
> **Docs** (CHANGELOG, API reference, YARD) now describe override vs inherited behavior. **Specs** cover ingestion and direct Scores API paths, override precedence, and omitting `environment` when nothing is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc78284b4d8a81ecc02179eebf14bc19c2c53f83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->