### PR TITLE
feat(config): read Langfuse batching and debug environment variables

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -598,6 +598,10 @@ The SDK automatically reads these environment variables as defaults when no expl
 - `LANGFUSE_PUBLIC_KEY` — public API key
 - `LANGFUSE_SECRET_KEY` — secret API key
 - `LANGFUSE_BASE_URL` — API endpoint (defaults to `https://cloud.langfuse.com`)
+- `LANGFUSE_TIMEOUT` — HTTP request timeout in seconds (defaults to `5`)
+- `LANGFUSE_FLUSH_AT` — maximum score and trace batch size (defaults to `50`)
+- `LANGFUSE_FLUSH_INTERVAL` — maximum batch wait in seconds (defaults to `10`)
+- `LANGFUSE_DEBUG` — set to `true` to use the `DEBUG` logger level
 - `LANGFUSE_TRACING_ENVIRONMENT` — default trace environment
 - `LANGFUSE_RELEASE` — default release identifier (falls back to common CI commit envs if present)
 - `LANGFUSE_SAMPLE_RATE` — trace sampling rate (`0.0..1.0`, defaults to `1.0`)
@@ -618,6 +622,10 @@ end
 LANGFUSE_PUBLIC_KEY=pk-lf-...
 LANGFUSE_SECRET_KEY=sk-lf-...
 LANGFUSE_BASE_URL=https://cloud.langfuse.com  # Optional
+LANGFUSE_TIMEOUT=10                           # Optional
+LANGFUSE_FLUSH_AT=100                         # Optional
+LANGFUSE_FLUSH_INTERVAL=5                     # Optional
+LANGFUSE_DEBUG=true                           # Optional
 LANGFUSE_SAMPLE_RATE=0.25                     # Optional
 ```
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -601,7 +601,7 @@ The SDK automatically reads these environment variables as defaults when no expl
 - `LANGFUSE_TIMEOUT` — HTTP request timeout in seconds (defaults to `5`)
 - `LANGFUSE_FLUSH_AT` — maximum score and trace batch size (defaults to `50`)
 - `LANGFUSE_FLUSH_INTERVAL` — maximum batch wait in seconds (defaults to `10`)
-- `LANGFUSE_DEBUG` — set to `true` to use the `DEBUG` logger level
+- `LANGFUSE_DEBUG` — set to `true` to write SDK logs to stdout at the `DEBUG` level
 - `LANGFUSE_TRACING_ENVIRONMENT` — default trace environment
 - `LANGFUSE_RELEASE` — default release identifier (falls back to common CI commit envs if present)
 - `LANGFUSE_SAMPLE_RATE` — trace sampling rate (`0.0..1.0`, defaults to `1.0`)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -599,7 +599,7 @@ The SDK automatically reads these environment variables as defaults when no expl
 - `LANGFUSE_SECRET_KEY` — secret API key
 - `LANGFUSE_BASE_URL` — API endpoint (defaults to `https://cloud.langfuse.com`)
 - `LANGFUSE_TIMEOUT` — HTTP request timeout in seconds (defaults to `5`)
-- `LANGFUSE_FLUSH_AT` — maximum score and trace batch size (defaults to `50`)
+- `LANGFUSE_FLUSH_AT` — score flush threshold and maximum trace batch size (defaults to `50`)
 - `LANGFUSE_FLUSH_INTERVAL` — maximum batch wait in seconds (defaults to `10`)
 - `LANGFUSE_DEBUG` — set to `true` to write SDK logs to stdout at the `DEBUG` level
 - `LANGFUSE_TRACING_ENVIRONMENT` — default trace environment

--- a/lib/langfuse/config.rb
+++ b/lib/langfuse/config.rb
@@ -192,21 +192,9 @@ module Langfuse
       @public_key = ENV.fetch("LANGFUSE_PUBLIC_KEY", nil)
       @secret_key = ENV.fetch("LANGFUSE_SECRET_KEY", nil)
       @base_url = ENV.fetch("LANGFUSE_BASE_URL", DEFAULT_BASE_URL)
-      @timeout = DEFAULT_TIMEOUT
-      @cache_ttl = DEFAULT_CACHE_TTL
-      @cache_max_size = DEFAULT_CACHE_MAX_SIZE
-      @cache_backend = DEFAULT_CACHE_BACKEND
-      @cache_lock_timeout = DEFAULT_CACHE_LOCK_TIMEOUT
-      @cache_stale_while_revalidate = DEFAULT_CACHE_STALE_WHILE_REVALIDATE
-      @cache_stale_ttl = 0 # Default to 0 (SWR disabled, entries expire immediately after TTL)
-      @cache_refresh_threads = DEFAULT_CACHE_REFRESH_THREADS
-      @prompt_cache_observer = nil
-      @tracing_async = DEFAULT_TRACING_ASYNC
-      @batch_size = DEFAULT_BATCH_SIZE
-      @flush_interval = DEFAULT_FLUSH_INTERVAL
-      @job_queue = DEFAULT_JOB_QUEUE
+      initialize_client_defaults
       initialize_tracing_defaults
-      self.logger = default_logger
+      initialize_logger
 
       yield(self) if block_given?
     end
@@ -288,6 +276,27 @@ module Langfuse
     end
 
     private
+
+    def initialize_client_defaults
+      @timeout = env_integer("LANGFUSE_TIMEOUT") || DEFAULT_TIMEOUT
+      @cache_ttl = DEFAULT_CACHE_TTL
+      @cache_max_size = DEFAULT_CACHE_MAX_SIZE
+      @cache_backend = DEFAULT_CACHE_BACKEND
+      @cache_lock_timeout = DEFAULT_CACHE_LOCK_TIMEOUT
+      @cache_stale_while_revalidate = DEFAULT_CACHE_STALE_WHILE_REVALIDATE
+      @cache_stale_ttl = 0 # Default to 0 (SWR disabled, entries expire immediately after TTL)
+      @cache_refresh_threads = DEFAULT_CACHE_REFRESH_THREADS
+      @prompt_cache_observer = nil
+      @tracing_async = DEFAULT_TRACING_ASYNC
+      @batch_size = env_integer("LANGFUSE_FLUSH_AT") || DEFAULT_BATCH_SIZE
+      @flush_interval = env_float("LANGFUSE_FLUSH_INTERVAL") || DEFAULT_FLUSH_INTERVAL
+      @job_queue = DEFAULT_JOB_QUEUE
+    end
+
+    def initialize_logger
+      self.logger = default_logger
+      @logger.level = Logger::DEBUG if env_true?("LANGFUSE_DEBUG")
+    end
 
     def default_logger
       return Rails.logger if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
@@ -467,6 +476,28 @@ module Langfuse
       return nil if value.nil? || value.empty?
 
       value
+    end
+
+    def env_integer(key)
+      value = env_value(key)
+      return nil unless value
+
+      Integer(value, 10)
+    rescue ArgumentError, TypeError
+      raise ConfigurationError, "#{key} must be an integer"
+    end
+
+    def env_float(key)
+      value = env_value(key)
+      return nil unless value
+
+      Float(value)
+    rescue ArgumentError, TypeError
+      raise ConfigurationError, "#{key} must be numeric"
+    end
+
+    def env_true?(key)
+      env_value(key)&.casecmp?("true") || false
     end
 
     def coerce_sample_rate(value)

--- a/lib/langfuse/config.rb
+++ b/lib/langfuse/config.rb
@@ -294,8 +294,11 @@ module Langfuse
     end
 
     def initialize_logger
-      self.logger = default_logger
-      @logger.level = Logger::DEBUG if env_true?("LANGFUSE_DEBUG")
+      self.logger = if env_true?("LANGFUSE_DEBUG")
+                      Logger.new($stdout, level: Logger::DEBUG)
+                    else
+                      default_logger
+                    end
     end
 
     def default_logger

--- a/spec/langfuse/config_environment_spec.rb
+++ b/spec/langfuse/config_environment_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe Langfuse::Config do
+  describe "environment defaults" do
+    it "reads timeout, batching, and debug settings" do
+      ENV["LANGFUSE_TIMEOUT"] = "9"
+      ENV["LANGFUSE_FLUSH_AT"] = "25"
+      ENV["LANGFUSE_FLUSH_INTERVAL"] = "1.5"
+      ENV["LANGFUSE_DEBUG"] = "true"
+      debug_logger = Logger.new(StringIO.new, level: Logger::DEBUG)
+      allow(Logger).to receive(:new).with($stdout, level: Logger::DEBUG).and_return(debug_logger)
+
+      config = described_class.new
+
+      expect(config.timeout).to eq(9)
+      expect(config.batch_size).to eq(25)
+      expect(config.flush_interval).to eq(1.5)
+      expect(config.logger).to equal(debug_logger)
+    ensure
+      clear_environment
+    end
+
+    it "prefers explicit Ruby settings" do
+      ENV["LANGFUSE_TIMEOUT"] = "9"
+      ENV["LANGFUSE_FLUSH_AT"] = "25"
+      ENV["LANGFUSE_FLUSH_INTERVAL"] = "1.5"
+      ENV["LANGFUSE_DEBUG"] = "true"
+
+      config = described_class.new do |candidate|
+        candidate.timeout = 12
+        candidate.batch_size = 30
+        candidate.flush_interval = 2
+        candidate.logger = Logger.new(StringIO.new, level: Logger::ERROR)
+      end
+
+      expect(config.timeout).to eq(12)
+      expect(config.batch_size).to eq(30)
+      expect(config.flush_interval).to eq(2)
+      expect(config.logger.level).to eq(Logger::ERROR)
+    ensure
+      clear_environment
+    end
+
+    it "does not change the Rails logger level when debug logging is enabled" do
+      ENV["LANGFUSE_DEBUG"] = "true"
+      rails_logger = Logger.new(StringIO.new, level: Logger::WARN)
+      debug_logger = Logger.new(StringIO.new, level: Logger::DEBUG)
+      stub_const("Rails", Class.new)
+      allow(Rails).to receive_messages(respond_to?: true, logger: rails_logger)
+      allow(Logger).to receive(:new).with($stdout, level: Logger::DEBUG).and_return(debug_logger)
+
+      config = described_class.new
+
+      expect(config.logger).to equal(debug_logger)
+      expect(rails_logger.level).to eq(Logger::WARN)
+    ensure
+      clear_environment
+    end
+
+    it "raises ConfigurationError for non-numeric values" do
+      invalid_values = {
+        "LANGFUSE_TIMEOUT" => "slow",
+        "LANGFUSE_FLUSH_AT" => "many",
+        "LANGFUSE_FLUSH_INTERVAL" => "often"
+      }
+
+      invalid_values.each do |key, value|
+        ENV[key] = value
+
+        expect { described_class.new }.to raise_error(Langfuse::ConfigurationError, /#{key}/)
+
+        ENV.delete(key)
+      end
+    ensure
+      clear_environment
+    end
+
+    def clear_environment
+      %w[
+        LANGFUSE_TIMEOUT
+        LANGFUSE_FLUSH_AT
+        LANGFUSE_FLUSH_INTERVAL
+        LANGFUSE_DEBUG
+      ].each { |key| ENV.delete(key) }
+    end
+  end
+end

--- a/spec/langfuse/config_spec.rb
+++ b/spec/langfuse/config_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Langfuse::Config do
       ENV["LANGFUSE_TRACING_ENVIRONMENT"] = "staging"
       ENV["LANGFUSE_RELEASE"] = "release-123"
       ENV["LANGFUSE_SAMPLE_RATE"] = "0.25"
+      ENV["LANGFUSE_TIMEOUT"] = "9"
+      ENV["LANGFUSE_FLUSH_AT"] = "25"
+      ENV["LANGFUSE_FLUSH_INTERVAL"] = "1.5"
+      ENV["LANGFUSE_DEBUG"] = "true"
 
       config = described_class.new
 
@@ -33,6 +37,10 @@ RSpec.describe Langfuse::Config do
       expect(config.environment).to eq("staging")
       expect(config.release).to eq("release-123")
       expect(config.sample_rate).to eq(0.25)
+      expect(config.timeout).to eq(9)
+      expect(config.batch_size).to eq(25)
+      expect(config.flush_interval).to eq(1.5)
+      expect(config.logger.level).to eq(Logger::DEBUG)
     ensure
       ENV.delete("LANGFUSE_PUBLIC_KEY")
       ENV.delete("LANGFUSE_SECRET_KEY")
@@ -40,6 +48,52 @@ RSpec.describe Langfuse::Config do
       ENV.delete("LANGFUSE_TRACING_ENVIRONMENT")
       ENV.delete("LANGFUSE_RELEASE")
       ENV.delete("LANGFUSE_SAMPLE_RATE")
+      ENV.delete("LANGFUSE_TIMEOUT")
+      ENV.delete("LANGFUSE_FLUSH_AT")
+      ENV.delete("LANGFUSE_FLUSH_INTERVAL")
+      ENV.delete("LANGFUSE_DEBUG")
+    end
+
+    it "prefers explicit batching, timeout, and logger settings over environment variables" do
+      ENV["LANGFUSE_TIMEOUT"] = "9"
+      ENV["LANGFUSE_FLUSH_AT"] = "25"
+      ENV["LANGFUSE_FLUSH_INTERVAL"] = "1.5"
+      ENV["LANGFUSE_DEBUG"] = "true"
+
+      config = described_class.new do |candidate|
+        candidate.timeout = 12
+        candidate.batch_size = 30
+        candidate.flush_interval = 2
+        candidate.logger.level = Logger::ERROR
+      end
+
+      expect(config.timeout).to eq(12)
+      expect(config.batch_size).to eq(30)
+      expect(config.flush_interval).to eq(2)
+      expect(config.logger.level).to eq(Logger::ERROR)
+    ensure
+      ENV.delete("LANGFUSE_TIMEOUT")
+      ENV.delete("LANGFUSE_FLUSH_AT")
+      ENV.delete("LANGFUSE_FLUSH_INTERVAL")
+      ENV.delete("LANGFUSE_DEBUG")
+    end
+
+    it "raises ConfigurationError for non-numeric batching and timeout environment values" do
+      invalid_values = {
+        "LANGFUSE_TIMEOUT" => "slow",
+        "LANGFUSE_FLUSH_AT" => "many",
+        "LANGFUSE_FLUSH_INTERVAL" => "often"
+      }
+
+      invalid_values.each do |key, value|
+        ENV[key] = value
+
+        expect { described_class.new }.to raise_error(Langfuse::ConfigurationError, /#{key}/)
+
+        ENV.delete(key)
+      end
+    ensure
+      invalid_values&.each_key { |key| ENV.delete(key) }
     end
 
     it "raises ConfigurationError for invalid LANGFUSE_SAMPLE_RATE" do

--- a/spec/langfuse/config_spec.rb
+++ b/spec/langfuse/config_spec.rb
@@ -24,11 +24,6 @@ RSpec.describe Langfuse::Config do
       ENV["LANGFUSE_TRACING_ENVIRONMENT"] = "staging"
       ENV["LANGFUSE_RELEASE"] = "release-123"
       ENV["LANGFUSE_SAMPLE_RATE"] = "0.25"
-      ENV["LANGFUSE_TIMEOUT"] = "9"
-      ENV["LANGFUSE_FLUSH_AT"] = "25"
-      ENV["LANGFUSE_FLUSH_INTERVAL"] = "1.5"
-      ENV["LANGFUSE_DEBUG"] = "true"
-
       config = described_class.new
 
       expect(config.public_key).to eq("test_public")
@@ -37,10 +32,6 @@ RSpec.describe Langfuse::Config do
       expect(config.environment).to eq("staging")
       expect(config.release).to eq("release-123")
       expect(config.sample_rate).to eq(0.25)
-      expect(config.timeout).to eq(9)
-      expect(config.batch_size).to eq(25)
-      expect(config.flush_interval).to eq(1.5)
-      expect(config.logger.level).to eq(Logger::DEBUG)
     ensure
       ENV.delete("LANGFUSE_PUBLIC_KEY")
       ENV.delete("LANGFUSE_SECRET_KEY")
@@ -48,52 +39,6 @@ RSpec.describe Langfuse::Config do
       ENV.delete("LANGFUSE_TRACING_ENVIRONMENT")
       ENV.delete("LANGFUSE_RELEASE")
       ENV.delete("LANGFUSE_SAMPLE_RATE")
-      ENV.delete("LANGFUSE_TIMEOUT")
-      ENV.delete("LANGFUSE_FLUSH_AT")
-      ENV.delete("LANGFUSE_FLUSH_INTERVAL")
-      ENV.delete("LANGFUSE_DEBUG")
-    end
-
-    it "prefers explicit batching, timeout, and logger settings over environment variables" do
-      ENV["LANGFUSE_TIMEOUT"] = "9"
-      ENV["LANGFUSE_FLUSH_AT"] = "25"
-      ENV["LANGFUSE_FLUSH_INTERVAL"] = "1.5"
-      ENV["LANGFUSE_DEBUG"] = "true"
-
-      config = described_class.new do |candidate|
-        candidate.timeout = 12
-        candidate.batch_size = 30
-        candidate.flush_interval = 2
-        candidate.logger.level = Logger::ERROR
-      end
-
-      expect(config.timeout).to eq(12)
-      expect(config.batch_size).to eq(30)
-      expect(config.flush_interval).to eq(2)
-      expect(config.logger.level).to eq(Logger::ERROR)
-    ensure
-      ENV.delete("LANGFUSE_TIMEOUT")
-      ENV.delete("LANGFUSE_FLUSH_AT")
-      ENV.delete("LANGFUSE_FLUSH_INTERVAL")
-      ENV.delete("LANGFUSE_DEBUG")
-    end
-
-    it "raises ConfigurationError for non-numeric batching and timeout environment values" do
-      invalid_values = {
-        "LANGFUSE_TIMEOUT" => "slow",
-        "LANGFUSE_FLUSH_AT" => "many",
-        "LANGFUSE_FLUSH_INTERVAL" => "often"
-      }
-
-      invalid_values.each do |key, value|
-        ENV[key] = value
-
-        expect { described_class.new }.to raise_error(Langfuse::ConfigurationError, /#{key}/)
-
-        ENV.delete(key)
-      end
-    ensure
-      invalid_values&.each_key { |key| ENV.delete(key) }
     end
 
     it "raises ConfigurationError for invalid LANGFUSE_SAMPLE_RATE" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,10 @@ RSpec.configure do |config|
     ENV.delete("LANGFUSE_TRACING_ENVIRONMENT")
     ENV.delete("LANGFUSE_RELEASE")
     ENV.delete("LANGFUSE_SAMPLE_RATE")
+    ENV.delete("LANGFUSE_TIMEOUT")
+    ENV.delete("LANGFUSE_FLUSH_AT")
+    ENV.delete("LANGFUSE_FLUSH_INTERVAL")
+    ENV.delete("LANGFUSE_DEBUG")
 
     # Stub OTLP endpoint BEFORE reset (which may flush traces)
     # (tests can override this with more specific stubs if needed)


### PR DESCRIPTION
#### `TL;DR`
<!-- One sentence -->
Langfuse configuration now reads timeout, batching, and debug defaults from the standard environment variables.

#### `Why`
<!-- Motivation/context for this change -->
Ruby services can now use the same deployment settings as the official Python and JavaScript SDKs. Explicit Ruby configuration still takes precedence.

Linear issue: https://linear.app/simplepractice/issue/AAI-386/featconfig-read-langfuse-timeout-langfuse-flush-at-langfuse-flush

#### `Checklist`
- [x] Has label
- [x] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)

Closes #

> [!NOTE]
> **Kade's words:**

## Summary

Configuration now reads `LANGFUSE_TIMEOUT`, `LANGFUSE_FLUSH_AT`, `LANGFUSE_FLUSH_INTERVAL`, and `LANGFUSE_DEBUG`. A configuration block can override every environment-derived value. Invalid numeric values raise `Langfuse::ConfigurationError`. The configuration guide documents the variables, defaults, and precedence.

The change keeps `LANGFUSE_HOST` out of the Ruby SDK. Python retains that variable only as a deprecated alias, and JavaScript does not support it.

### Change diagram

```mermaid
flowchart LR
  accTitle: Configuration value precedence
  accDescr: Explicit Ruby configuration overrides environment variables, which override SDK defaults.
  A["SDK defaults"] --> B["Environment values"]
  B --> C["Ruby configuration block"]
  C --> D["Effective configuration"]
```

The last configured source supplies the effective value.

## Verification

I ran the complete RSpec suite locally. All 1,572 examples passed. Line coverage was 97.26 percent. I ran RuboCop across all 96 inspected files. RuboCop found no offenses.

I loaded the project credentials from `.env`. I sent a trace and an asynchronous score with the Ruby SDK while all four new environment variables were set. `Langfuse.shutdown` completed successfully. The Langfuse CLI returned the trace with its input and output. The CLI also returned the linked numeric score.

I reviewed the Mermaid source for syntax and behavior accuracy. I did not preview the rendered diagram in GitHub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only configuration with clear precedence and validation; no auth or export pipeline logic changes beyond reading defaults from the environment.
> 
> **Overview**
> **`Langfuse::Config`** now picks up **`LANGFUSE_TIMEOUT`**, **`LANGFUSE_FLUSH_AT`** (maps to `batch_size`), **`LANGFUSE_FLUSH_INTERVAL`**, and **`LANGFUSE_DEBUG`** on init, matching the Python/JS SDK env names. Initialization is split into **`initialize_client_defaults`** and **`initialize_logger`**; parsing uses new **`env_integer`**, **`env_float`**, and **`env_true?`** helpers that raise **`Langfuse::ConfigurationError`** when numeric env values are invalid.
> 
> **`LANGFUSE_DEBUG=true`** switches the SDK logger to stdout at **DEBUG** without changing **`Rails.logger`**. Values set in a **`Langfuse.configure`** block still override env defaults. **CONFIGURATION.md** documents the variables and example `.env` entries; **`config_environment_spec`** and **`spec_helper`** cover the new behavior and env cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0790752cd19b19964c4d3f7d7ae360e76c9fbe54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->