### PR TITLE
fix(runtime): restore background workers after fork

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -705,7 +705,7 @@ See [CACHING.md](CACHING.md) for performance comparison.
 The SDK restores its background state after `fork` on Ruby 3.2 and later. This applies to Puma cluster workers, Unicorn workers, Resque workers, and other processes created through Ruby's standard fork path.
 
 - The child receives a new score queue and flush timer.
-- The child receives new prompt-cache synchronization objects and stale-while-revalidate worker pools.
+- The child receives new prompt-cache synchronization objects. `concurrent-ruby` resets stale-while-revalidate worker state on the first child submission.
 - Scores queued before the fork remain owned by the parent. The child discards its copied queue to prevent duplicate ingestion.
 - In-memory prompt values remain available in the child. Rails cache data remains owned by the configured Rails cache store.
 - OpenTelemetry's batch span processor performs its own process-ID reset for trace export.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -700,6 +700,18 @@ config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
 
 See [CACHING.md](CACHING.md) for performance comparison.
 
+## Forking Servers and Workers
+
+The SDK restores its background state after `fork` on Ruby 3.2 and later. This applies to Puma cluster workers, Unicorn workers, Resque workers, and other processes created through Ruby's standard fork path.
+
+- The child receives a new score queue and flush timer.
+- The child receives new prompt-cache synchronization objects and stale-while-revalidate worker pools.
+- Scores queued before the fork remain owned by the parent. The child discards its copied queue to prevent duplicate ingestion.
+- In-memory prompt values remain available in the child. Rails cache data remains owned by the configured Rails cache store.
+- OpenTelemetry's batch span processor performs its own process-ID reset for trace export.
+
+The parent keeps its original queue and worker objects. Shutdown remains independent in each process.
+
 ## Configuration by Environment
 
 ### Development

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -40,6 +40,7 @@ module Langfuse
 end
 
 require_relative "langfuse/config"
+require_relative "langfuse/fork_safety"
 require_relative "langfuse/cache_constants"
 require_relative "langfuse/prompt_cache"
 require_relative "langfuse/prompt_fetch_result"

--- a/lib/langfuse/fork_safety.rb
+++ b/lib/langfuse/fork_safety.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Langfuse
+  # Restores SDK-owned background state in a forked child process.
+  #
+  # @api private
+  module ForkSafety
+    # Ruby routes Kernel#fork, Process.fork, and IO.popen("-") through
+    # Process._fork. Ruby 3.2 documents this override point for monitoring
+    # libraries that need before-fork or after-fork behavior.
+    module ProcessHook
+      def _fork
+        pid = super
+        Langfuse::ForkSafety.after_fork if pid.zero?
+        pid
+      end
+    end
+
+    class << self
+      # Register an SDK resource that implements a private #reset_after_fork method.
+      #
+      # @param resource [Object] Fork-sensitive SDK resource
+      # @return [void]
+      def register(resource)
+        install!
+        registry_mutex.synchronize { registry[resource] = true }
+      end
+
+      # Reset every live registered resource in the child process.
+      #
+      # @return [void]
+      def after_fork
+        reset_inherited_mutexes
+        registry.each_key { |resource| reset_resource(resource) }
+      rescue StandardError => e
+        Kernel.warn("Langfuse fork reset failed: #{e.class} - #{e.message}")
+      end
+
+      private
+
+      def install!
+        install_mutex.synchronize do
+          Process.singleton_class.prepend(ProcessHook) unless Process.singleton_class.ancestors.include?(ProcessHook)
+        end
+      end
+
+      def registry
+        @registry ||= ObjectSpace::WeakMap.new
+      end
+
+      def registry_mutex
+        @registry_mutex ||= Mutex.new
+      end
+
+      def install_mutex
+        @install_mutex ||= Mutex.new
+      end
+
+      def reset_inherited_mutexes
+        @registry_mutex = Mutex.new
+        @install_mutex = Mutex.new
+      end
+
+      def reset_resource(resource)
+        resource.__send__(:reset_after_fork)
+      rescue StandardError => e
+        Kernel.warn("Langfuse fork reset failed for #{resource.class}: #{e.class} - #{e.message}")
+      end
+    end
+  end
+end

--- a/lib/langfuse/prompt_cache.rb
+++ b/lib/langfuse/prompt_cache.rb
@@ -3,6 +3,7 @@
 require "monitor"
 require "base64"
 require_relative "stale_while_revalidate"
+require_relative "fork_safety"
 
 module Langfuse
   # Simple in-memory cache for prompt data with TTL
@@ -92,6 +93,7 @@ module Langfuse
       @monitor = Monitor.new
       @locks = {} # Track locks for in-memory locking
       initialize_swr(refresh_threads: refresh_threads) if swr_enabled?
+      ForkSafety.register(self)
     end
 
     # Get a value from the cache
@@ -283,6 +285,13 @@ module Langfuse
     end
 
     private
+
+    # Replace inherited synchronization and worker state in the child process.
+    def reset_after_fork
+      @monitor = Monitor.new
+      @locks = {}
+      reset_swr_after_fork
+    end
 
     # Implementation of StaleWhileRevalidate abstract methods
 

--- a/lib/langfuse/prompt_cache.rb
+++ b/lib/langfuse/prompt_cache.rb
@@ -290,7 +290,6 @@ module Langfuse
     def reset_after_fork
       @monitor = Monitor.new
       @locks = {}
-      reset_swr_after_fork
     end
 
     # Implementation of StaleWhileRevalidate abstract methods

--- a/lib/langfuse/rails_cache_adapter.rb
+++ b/lib/langfuse/rails_cache_adapter.rb
@@ -2,6 +2,7 @@
 
 require_relative "prompt_cache"
 require_relative "stale_while_revalidate"
+require_relative "fork_safety"
 
 module Langfuse
   # Rails.cache adapter for distributed caching with Redis
@@ -69,6 +70,7 @@ module Langfuse
       @generation_memo = {}
       @generation_memo_mutex = Mutex.new
       initialize_swr(refresh_threads: refresh_threads) if swr_enabled?
+      ForkSafety.register(self)
     end
 
     # Get a value from the cache
@@ -256,6 +258,13 @@ module Langfuse
     end
 
     private
+
+    # Replace inherited synchronization and worker state in the child process.
+    def reset_after_fork
+      @generation_memo = {}
+      @generation_memo_mutex = Mutex.new
+      reset_swr_after_fork
+    end
 
     # Implementation of StaleWhileRevalidate abstract methods
 

--- a/lib/langfuse/rails_cache_adapter.rb
+++ b/lib/langfuse/rails_cache_adapter.rb
@@ -263,7 +263,6 @@ module Langfuse
     def reset_after_fork
       @generation_memo = {}
       @generation_memo_mutex = Mutex.new
-      reset_swr_after_fork
     end
 
     # Implementation of StaleWhileRevalidate abstract methods

--- a/lib/langfuse/score_client.rb
+++ b/lib/langfuse/score_client.rb
@@ -2,6 +2,7 @@
 
 require "securerandom"
 require "opentelemetry/trace"
+require_relative "fork_safety"
 
 module Langfuse
   # Client for creating and batching Langfuse scores
@@ -50,6 +51,7 @@ module Langfuse
       @score_sampler = Sampling.build_sampler(config.sample_rate)
 
       start_flush_timer
+      ForkSafety.register(self)
     end
 
     # Create a score event and queue it for batching
@@ -264,6 +266,16 @@ module Langfuse
     end
 
     private
+
+    # Discard parent-owned queued work and restore the child process timer.
+    def reset_after_fork
+      inherited_shutdown = @shutdown
+      @queue = Queue.new
+      @mutex = Mutex.new
+      @flush_thread = nil
+      @shutdown = inherited_shutdown
+      start_flush_timer unless @shutdown
+    end
 
     # Validate score inputs and build the canonical API body.
     #

--- a/lib/langfuse/stale_while_revalidate.rb
+++ b/lib/langfuse/stale_while_revalidate.rb
@@ -51,6 +51,8 @@ module Langfuse
     # @param refresh_threads [Integer] Number of background refresh threads (default: 5)
     # @return [void]
     def initialize_swr(refresh_threads: 5)
+      @swr_refresh_threads = refresh_threads
+      @swr_shutdown = false
       @thread_pool = initialize_thread_pool(refresh_threads)
     end
 
@@ -143,13 +145,23 @@ module Langfuse
     #
     # @return [void]
     def shutdown
-      return unless @thread_pool
+      @swr_shutdown = true
+      thread_pool = @thread_pool
+      @thread_pool = nil
+      return unless thread_pool
 
-      @thread_pool.shutdown
-      @thread_pool.wait_for_termination(5) # Wait up to 5 seconds
+      thread_pool.shutdown
+      thread_pool.wait_for_termination(5) # Wait up to 5 seconds
     end
 
     private
+
+    def reset_swr_after_fork
+      @thread_pool = nil
+      return if @swr_shutdown || !@swr_refresh_threads
+
+      @thread_pool = initialize_thread_pool(@swr_refresh_threads)
+    end
 
     # Initialize thread pool for background refresh operations
     #

--- a/lib/langfuse/stale_while_revalidate.rb
+++ b/lib/langfuse/stale_while_revalidate.rb
@@ -51,8 +51,6 @@ module Langfuse
     # @param refresh_threads [Integer] Number of background refresh threads (default: 5)
     # @return [void]
     def initialize_swr(refresh_threads: 5)
-      @swr_refresh_threads = refresh_threads
-      @swr_shutdown = false
       @thread_pool = initialize_thread_pool(refresh_threads)
     end
 
@@ -145,23 +143,13 @@ module Langfuse
     #
     # @return [void]
     def shutdown
-      @swr_shutdown = true
-      thread_pool = @thread_pool
-      @thread_pool = nil
-      return unless thread_pool
+      return unless @thread_pool
 
-      thread_pool.shutdown
-      thread_pool.wait_for_termination(5) # Wait up to 5 seconds
+      @thread_pool.shutdown
+      @thread_pool.wait_for_termination(5) # Wait up to 5 seconds
     end
 
     private
-
-    def reset_swr_after_fork
-      @thread_pool = nil
-      return if @swr_shutdown || !@swr_refresh_threads
-
-      @thread_pool = initialize_thread_pool(@swr_refresh_threads)
-    end
 
     # Initialize thread pool for background refresh operations
     #
@@ -186,13 +174,12 @@ module Langfuse
     # @param key [String] Cache key
     # @yield Block to execute to fetch fresh data
     # @return [void]
-    # rubocop:disable Naming/PredicateMethod
     def schedule_refresh(key, ttl: nil, stale_ttl: nil, on_success: nil, on_failure: nil, &block)
       # Prevent duplicate refreshes
       lock_key = build_lock_key(key)
       return false unless acquire_lock(lock_key)
 
-      @thread_pool.post do
+      scheduled = @thread_pool.post do
         value = block.call
         set_cache_entry(key, value, ttl: ttl, stale_ttl: stale_ttl)
         on_success&.call(value)
@@ -203,9 +190,9 @@ module Langfuse
         release_lock(lock_key)
       end
 
-      true
+      release_lock(lock_key) unless scheduled
+      scheduled
     end
-    # rubocop:enable Naming/PredicateMethod
 
     # Fetch data and cache it with SWR metadata
     #

--- a/spec/langfuse/fork_safety_spec.rb
+++ b/spec/langfuse/fork_safety_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Langfuse::ForkSafety do
+  describe ".register" do
+    it "runs the registered reset once in a forked child" do
+      skip "fork is not available" unless Process.respond_to?(:fork)
+
+      resource_class = Class.new do
+        attr_reader :reset_pid, :reset_count
+
+        def initialize
+          @reset_count = 0
+        end
+
+        private
+
+        def reset_after_fork
+          @reset_pid = Process.pid
+          @reset_count += 1
+        end
+      end
+      resource = resource_class.new
+      described_class.register(resource)
+      child_pid, status, child_state = capture_forked_state do
+        { pid: resource.reset_pid, count: resource.reset_count }
+      end
+
+      expect(status).to be_success
+      expect(child_state).to eq(pid: child_pid, count: 1)
+      expect(resource.reset_count).to eq(0)
+    end
+
+    it "installs one process hook for repeated registrations" do
+      resource_class = Class.new do
+        private
+
+        def reset_after_fork; end
+      end
+      resources = Array.new(2) { resource_class.new }
+      resources.each { |resource| described_class.register(resource) }
+
+      hook_count = Process.singleton_class.ancestors.count do |ancestor|
+        ancestor.equal?(described_class::ProcessHook)
+      end
+
+      expect(hook_count).to eq(1)
+    end
+  end
+end

--- a/spec/langfuse/fork_safety_spec.rb
+++ b/spec/langfuse/fork_safety_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Langfuse::ForkSafety do
   describe ".register" do
-    it "runs the registered reset once in a forked child" do
+    it "runs the registered reset once after each fork" do
       skip "fork is not available" unless Process.respond_to?(:fork)
 
       resource_class = Class.new do
@@ -21,12 +21,16 @@ RSpec.describe Langfuse::ForkSafety do
       end
       resource = resource_class.new
       described_class.register(resource)
-      child_pid, status, child_state = capture_forked_state do
-        { pid: resource.reset_pid, count: resource.reset_count }
+
+      2.times do
+        child_pid, status, child_state = capture_forked_state do
+          { pid: resource.reset_pid, count: resource.reset_count }
+        end
+
+        expect(status).to be_success
+        expect(child_state).to eq(pid: child_pid, count: 1)
       end
 
-      expect(status).to be_success
-      expect(child_state).to eq(pid: child_pid, count: 1)
       expect(resource.reset_count).to eq(0)
     end
 

--- a/spec/langfuse/prompt_cache_spec.rb
+++ b/spec/langfuse/prompt_cache_spec.rb
@@ -479,12 +479,19 @@ RSpec.describe Langfuse::PromptCache do
       expect { cache.shutdown }.not_to raise_error
     end
 
-    it "refreshes stale data with a new worker pool in a forked child" do
+    it "rejects a refresh without retaining its lock after shutdown" do
+      cache = described_class.new(ttl: 60, stale_ttl: 120)
+      cache.shutdown
+
+      expect(cache.refresh_async("stopped") { "unused" }).to be false
+      expect(cache.instance_variable_get(:@locks)).to be_empty
+    end
+
+    it "refreshes stale data in a forked child" do
       skip "fork is not available" unless Process.respond_to?(:fork)
 
       fork_cache = described_class.new(ttl: 60, stale_ttl: 120, refresh_threads: 1)
       fork_cache.set("fork-key", "parent")
-      parent_pool = fork_cache.instance_variable_get(:@thread_pool)
       _child_pid, status, child_state = capture_forked_state do
         child_pool = fork_cache.instance_variable_get(:@thread_pool)
         fork_cache.refresh_async("fork-key") { "child" }
@@ -492,15 +499,13 @@ RSpec.describe Langfuse::PromptCache do
         sleep(0.01) while fork_cache.get("fork-key") != "child" &&
                           Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
         {
-          pool_replaced: !child_pool.equal?(parent_pool),
           pool_running: child_pool.running?,
           value: fork_cache.get("fork-key")
         }
       end
 
       expect(status).to be_success
-      expect(child_state).to eq(pool_replaced: true, pool_running: true, value: "child")
-      expect(fork_cache.instance_variable_get(:@thread_pool)).to equal(parent_pool)
+      expect(child_state).to eq(pool_running: true, value: "child")
       expect(fork_cache.get("fork-key")).to eq("parent")
     ensure
       fork_cache&.shutdown

--- a/spec/langfuse/prompt_cache_spec.rb
+++ b/spec/langfuse/prompt_cache_spec.rb
@@ -478,5 +478,32 @@ RSpec.describe Langfuse::PromptCache do
 
       expect { cache.shutdown }.not_to raise_error
     end
+
+    it "refreshes stale data with a new worker pool in a forked child" do
+      skip "fork is not available" unless Process.respond_to?(:fork)
+
+      fork_cache = described_class.new(ttl: 60, stale_ttl: 120, refresh_threads: 1)
+      fork_cache.set("fork-key", "parent")
+      parent_pool = fork_cache.instance_variable_get(:@thread_pool)
+      _child_pid, status, child_state = capture_forked_state do
+        child_pool = fork_cache.instance_variable_get(:@thread_pool)
+        fork_cache.refresh_async("fork-key") { "child" }
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+        sleep(0.01) while fork_cache.get("fork-key") != "child" &&
+                          Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+        {
+          pool_replaced: !child_pool.equal?(parent_pool),
+          pool_running: child_pool.running?,
+          value: fork_cache.get("fork-key")
+        }
+      end
+
+      expect(status).to be_success
+      expect(child_state).to eq(pool_replaced: true, pool_running: true, value: "child")
+      expect(fork_cache.instance_variable_get(:@thread_pool)).to equal(parent_pool)
+      expect(fork_cache.get("fork-key")).to eq("parent")
+    ensure
+      fork_cache&.shutdown
+    end
   end
 end

--- a/spec/langfuse/rails_cache_adapter_spec.rb
+++ b/spec/langfuse/rails_cache_adapter_spec.rb
@@ -1157,16 +1157,12 @@ RSpec.describe Langfuse::RailsCacheAdapter do
       skip "fork is not available" unless Process.respond_to?(:fork)
 
       adapter = described_class.new(ttl: 60, stale_ttl: 120, refresh_threads: 1)
-      parent_pool = adapter.thread_pool
       parent_mutex = adapter.instance_variable_get(:@generation_memo_mutex)
       adapter.instance_variable_get(:@generation_memo)["prompt"] = { value: 1 }
 
       _child_pid, status, child_state = capture_forked_state do
-        child_pool = adapter.thread_pool
         child_mutex = adapter.instance_variable_get(:@generation_memo_mutex)
         {
-          pool_replaced: !child_pool.equal?(parent_pool),
-          pool_running: child_pool.running?,
           mutex_replaced: !child_mutex.equal?(parent_mutex),
           generation_memo: adapter.instance_variable_get(:@generation_memo)
         }
@@ -1174,12 +1170,9 @@ RSpec.describe Langfuse::RailsCacheAdapter do
 
       expect(status).to be_success
       expect(child_state).to eq(
-        pool_replaced: true,
-        pool_running: true,
         mutex_replaced: true,
         generation_memo: {}
       )
-      expect(adapter.thread_pool).to equal(parent_pool)
       expect(adapter.instance_variable_get(:@generation_memo_mutex)).to equal(parent_mutex)
       expect(adapter.instance_variable_get(:@generation_memo)).to eq("prompt" => { value: 1 })
     ensure

--- a/spec/langfuse/rails_cache_adapter_spec.rb
+++ b/spec/langfuse/rails_cache_adapter_spec.rb
@@ -1151,4 +1151,39 @@ RSpec.describe Langfuse::RailsCacheAdapter do
       end
     end
   end
+
+  describe "fork safety" do
+    it "replaces inherited worker and synchronization state in a forked child" do
+      skip "fork is not available" unless Process.respond_to?(:fork)
+
+      adapter = described_class.new(ttl: 60, stale_ttl: 120, refresh_threads: 1)
+      parent_pool = adapter.thread_pool
+      parent_mutex = adapter.instance_variable_get(:@generation_memo_mutex)
+      adapter.instance_variable_get(:@generation_memo)["prompt"] = { value: 1 }
+
+      _child_pid, status, child_state = capture_forked_state do
+        child_pool = adapter.thread_pool
+        child_mutex = adapter.instance_variable_get(:@generation_memo_mutex)
+        {
+          pool_replaced: !child_pool.equal?(parent_pool),
+          pool_running: child_pool.running?,
+          mutex_replaced: !child_mutex.equal?(parent_mutex),
+          generation_memo: adapter.instance_variable_get(:@generation_memo)
+        }
+      end
+
+      expect(status).to be_success
+      expect(child_state).to eq(
+        pool_replaced: true,
+        pool_running: true,
+        mutex_replaced: true,
+        generation_memo: {}
+      )
+      expect(adapter.thread_pool).to equal(parent_pool)
+      expect(adapter.instance_variable_get(:@generation_memo_mutex)).to equal(parent_mutex)
+      expect(adapter.instance_variable_get(:@generation_memo)).to eq("prompt" => { value: 1 })
+    ensure
+      adapter&.shutdown
+    end
+  end
 end

--- a/spec/langfuse/score_client_spec.rb
+++ b/spec/langfuse/score_client_spec.rb
@@ -42,6 +42,39 @@ RSpec.describe Langfuse::ScoreClient do
       sleep(0.1)
       expect(score_client.instance_variable_get(:@flush_thread)).to be_alive
     end
+
+    it "replaces inherited queue and timer state in a forked child" do
+      skip "fork is not available" unless Process.respond_to?(:fork)
+
+      allow(api_client).to receive(:send_batch)
+      score_client.create(name: "parent-score", value: 1)
+      parent_queue = score_client.instance_variable_get(:@queue)
+      parent_thread = score_client.instance_variable_get(:@flush_thread)
+      child_pid, status, child_state = capture_forked_state do
+        score_client.create(name: "child-score", value: 1)
+        child_queue = score_client.instance_variable_get(:@queue)
+        child_thread = score_client.instance_variable_get(:@flush_thread)
+        score_client.flush
+        {
+          pid: Process.pid,
+          queue_replaced: !child_queue.equal?(parent_queue),
+          queue_empty_after_flush: child_queue.empty?,
+          timer_alive: child_thread&.alive?
+        }
+      end
+
+      expect(status).to be_success
+      expect(child_state).to eq(
+        pid: child_pid,
+        queue_replaced: true,
+        queue_empty_after_flush: true,
+        timer_alive: true
+      )
+      expect(score_client.instance_variable_get(:@queue)).to equal(parent_queue)
+      expect(score_client.instance_variable_get(:@queue).size).to eq(1)
+      expect(score_client.instance_variable_get(:@flush_thread)).to equal(parent_thread)
+      expect(parent_thread).to be_alive
+    end
   end
 
   describe "#create" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,11 @@ require "opentelemetry/sdk"
 require "webmock/rspec"
 require "logger"
 require "fileutils"
+require_relative "support/fork_test_helpers"
 
 RSpec.configure do |config|
+  config.include ForkTestHelpers
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 

--- a/spec/support/fork_test_helpers.rb
+++ b/spec/support/fork_test_helpers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ForkTestHelpers
+  def capture_forked_state
+    reader, writer = IO.pipe
+    child_pid = Process.fork do
+      reader.close
+      writer.write(Marshal.dump(yield))
+      writer.close
+      exit!(0)
+    end
+    writer.close
+    child_state = Marshal.load(reader.read) # rubocop:disable Security/MarshalLoad
+    _, status = Process.wait2(child_pid)
+    [child_pid, status, child_state]
+  ensure
+    reader&.close unless reader&.closed?
+    writer&.close unless writer&.closed?
+  end
+end

--- a/spec/support/fork_test_helpers.rb
+++ b/spec/support/fork_test_helpers.rb
@@ -1,20 +1,48 @@
 # frozen_string_literal: true
 
 module ForkTestHelpers
+  FORK_WAIT_SECONDS = 5
+  private_constant :FORK_WAIT_SECONDS
+
   def capture_forked_state
     reader, writer = IO.pipe
     child_pid = Process.fork do
       reader.close
       writer.write(Marshal.dump(yield))
       writer.close
-      exit!(0)
     end
     writer.close
-    child_state = Marshal.load(reader.read) # rubocop:disable Security/MarshalLoad
-    _, status = Process.wait2(child_pid)
-    [child_pid, status, child_state]
+    payload = read_child_payload(reader)
+    completed_child_pid, status = Process.wait2(child_pid)
+    child_pid = nil
+    child_state = payload.empty? ? nil : Marshal.load(payload) # rubocop:disable Security/MarshalLoad
+    [completed_child_pid, status, child_state]
   ensure
+    terminate_child(child_pid)
     reader&.close unless reader&.closed?
     writer&.close unless writer&.closed?
+  end
+
+  private
+
+  def read_child_payload(reader)
+    unless reader.wait_readable(FORK_WAIT_SECONDS)
+      raise "forked child did not respond within #{FORK_WAIT_SECONDS} seconds"
+    end
+
+    reader.read
+  end
+
+  def terminate_child(child_pid)
+    return unless child_pid
+
+    ignore_missing_process { Process.kill("KILL", child_pid) }
+    ignore_missing_process { Process.wait(child_pid) }
+  end
+
+  def ignore_missing_process
+    yield
+  rescue Errno::ECHILD, Errno::ESRCH
+    nil
   end
 end


### PR DESCRIPTION
#### `TL;DR`
Forked child processes now receive working score and prompt-cache background workers.

#### `Why`
Ruby drops all non-calling threads after `fork`. Inherited SDK queues, mutexes, and worker pools could not safely serve the child process.

#### `Checklist`
- [x] Has label
- [x] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)

Closes #

> [!NOTE]
> **Kade's words:**

## Summary

Forked child processes now replace inherited SDK background state before application code resumes. The child gets a new score queue, flush timer, prompt-cache locks, and stale-while-revalidate worker pools. Parent-owned queued scores remain in the parent to prevent duplicate ingestion.

The process hook uses Ruby's documented `Process._fork` extension point. OpenTelemetry keeps responsibility for its own batch span processor.

### Change diagram

```mermaid
flowchart LR
    accTitle: Forked child background state reset
    accDescr: The Ruby fork hook gives the child new score and cache workers while the parent keeps its state.
    P["Parent SDK state"] --> F["Ruby fork"]
    F --> C["Child process"]
    C --> R["Reset inherited state"]
    R --> Q["New score queue and timer"]
    R --> W["New cache locks and workers"]
    P --> K["Parent state stays unchanged"]
```

## Verification

I ran the complete RSpec suite locally. All 1,575 examples passed. Line coverage was 96.53%.

I ran RuboCop against 99 files. RuboCop reported no offenses.

I initialized the Ruby SDK before `fork`. The child created trace `03d9fdc7e9397554c695ec7aae0dbd92`, queued a score, and shut down cleanly. The Langfuse CLI read back the child observation and the `sdk-fork-child` score.

I also verified the real-fork tests for the score client, memory cache, Rails cache adapter, and process hook. The targeted tests passed. The targeted run does not meet the repository-wide coverage threshold because it loads only those files.

I did not preview the rendered Mermaid diagram in GitHub. I reviewed the Mermaid source and syntax locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-wide fork hooks and score ingestion paths; incorrect reset could duplicate or drop scores, though behavior is covered by fork integration specs.
> 
> **Overview**
> Adds **`Langfuse::ForkSafety`**, which hooks Ruby’s `Process._fork` and runs registered `#reset_after_fork` callbacks in forked children (Ruby 3.2+). **ScoreClient**, **PromptCache**, and **RailsCacheAdapter** register on init so inherited mutexes, queues, and timers are replaced in the child.
> 
> In the child, **ScoreClient** drops the copied score queue (parent keeps pre-fork scores), starts a new flush timer, and leaves shutdown state unchanged. Caches get fresh locks / memo state; SWR thread pools rely on **concurrent-ruby**’s fork behavior (documented in **CONFIGURATION.md**).
> 
> **StaleWhileRevalidate** now releases refresh locks when the thread pool rejects work and returns whether scheduling succeeded. Specs add fork helpers and integration tests for the hook and each component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c84a066571e3618f87cc1f0743b1bfc13c562a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->