### PR TITLE
fix(runtime): flush pending telemetry at process exit

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -712,6 +712,14 @@ The SDK restores its background state after `fork` on Ruby 3.2 and later. This a
 
 The parent keeps its original queue and worker objects. Shutdown remains independent in each process.
 
+## Process Exit
+
+The SDK automatically flushes pending spans and scores during normal process exit. One-off scripts and short-lived tasks do not need to register an `at_exit` callback.
+
+Call `Langfuse.shutdown` when the application must flush before process exit. An explicit shutdown disables the pending exit callback. `Langfuse.reset!` also disables the callback until the next SDK configuration lifecycle begins.
+
+The exit callback runs once and does not allow shutdown errors to escape the process-exit path. Abrupt termination, such as `SIGKILL`, cannot run process-exit callbacks.
+
 ## Configuration by Environment
 
 ### Development

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -82,15 +82,20 @@ require_relative "langfuse/client"
 module Langfuse
   # rubocop:disable Metrics/ClassLength
   class << self
+    # Set the global configuration object and start its process-exit lifecycle.
+    #
     # @param configuration [Config] the global configuration object
-    attr_writer :configuration
+    # @return [Config] the assigned configuration
+    def configuration=(configuration)
+      ExitHook.enable
+      @configuration = configuration
+    end
 
     # Returns the global configuration object
     #
     # @return [Config] the global configuration
     def configuration
-      ExitHook.enable
-      @configuration ||= Config.new
+      @configuration ||= Config.new.tap { ExitHook.enable }
     end
 
     # Configure Langfuse globally

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -87,6 +87,7 @@ module Langfuse
     # @param configuration [Config] the global configuration object
     # @return [Config] the assigned configuration
     def configuration=(configuration)
+      reset!
       ExitHook.enable
       @configuration = configuration
     end

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -41,6 +41,7 @@ end
 
 require_relative "langfuse/config"
 require_relative "langfuse/fork_safety"
+require_relative "langfuse/exit_hook"
 require_relative "langfuse/cache_constants"
 require_relative "langfuse/prompt_cache"
 require_relative "langfuse/prompt_fetch_result"
@@ -88,6 +89,7 @@ module Langfuse
     #
     # @return [Config] the global configuration
     def configuration
+      ExitHook.enable
       @configuration ||= Config.new
     end
 
@@ -153,10 +155,11 @@ module Langfuse
     # @param timeout [Integer] Timeout in seconds
     # @return [void]
     #
-    # @example In a Rails initializer or shutdown hook
-    #   at_exit { Langfuse.shutdown }
+    # @example Explicit early shutdown
+    #   Langfuse.shutdown
     #
     def shutdown(timeout: 30)
+      ExitHook.disable
       client.shutdown if @client
       OtelSetup.shutdown(timeout: timeout)
     end
@@ -409,6 +412,7 @@ module Langfuse
     #
     # @return [void]
     def reset!
+      ExitHook.disable
       client.shutdown if @client
       OtelSetup.shutdown(timeout: 5) if OtelSetup.initialized?
       @configuration = nil

--- a/lib/langfuse/exit_hook.rb
+++ b/lib/langfuse/exit_hook.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative "fork_safety"
+
+module Langfuse
+  # Flushes SDK telemetry during normal process exit.
+  #
+  # @api private
+  module ExitHook
+    class << self
+      # Install the process callback once and enable it.
+      #
+      # @return [void]
+      def install!
+        install_mutex.synchronize do
+          return if @installed
+
+          Kernel.at_exit { run }
+          @installed = true
+          @active = true
+        end
+      end
+
+      # Enable the installed callback for the current SDK lifecycle.
+      #
+      # @return [void]
+      def enable
+        state_mutex.synchronize { @active = true }
+      end
+
+      # Disable the callback after an explicit shutdown or reset.
+      #
+      # @return [void]
+      def disable
+        state_mutex.synchronize { @active = false }
+      end
+
+      # Run the callback once without allowing shutdown errors to escape.
+      #
+      # @return [void]
+      def run
+        return unless consume_active_hook
+
+        Langfuse.shutdown
+      rescue StandardError => e
+        warn_failure(e)
+      end
+
+      private
+
+      def consume_active_hook
+        state_mutex.synchronize do
+          active = @active
+          @active = false
+          active
+        end
+      end
+
+      def reset_after_fork
+        @install_mutex = Mutex.new
+        @state_mutex = Mutex.new
+      end
+
+      def install_mutex
+        @install_mutex ||= Mutex.new
+      end
+
+      def state_mutex
+        @state_mutex ||= Mutex.new
+      end
+
+      def warn_failure(error)
+        Kernel.warn("Langfuse exit flush failed: #{error.class} - #{error.message}")
+      rescue StandardError
+        nil
+      end
+    end
+
+    install!
+    ForkSafety.register(self)
+  end
+end

--- a/lib/langfuse/exit_hook.rb
+++ b/lib/langfuse/exit_hook.rb
@@ -12,12 +12,12 @@ module Langfuse
       #
       # @return [void]
       def install!
-        install_mutex.synchronize do
+        mutex.synchronize do
           return if @installed
 
           Kernel.at_exit { run }
           @installed = true
-          @active = true
+          @active = false
         end
       end
 
@@ -25,14 +25,14 @@ module Langfuse
       #
       # @return [void]
       def enable
-        state_mutex.synchronize { @active = true }
+        mutex.synchronize { @active = true }
       end
 
       # Disable the callback after an explicit shutdown or reset.
       #
       # @return [void]
       def disable
-        state_mutex.synchronize { @active = false }
+        mutex.synchronize { @active = false }
       end
 
       # Run the callback once without allowing shutdown errors to escape.
@@ -49,7 +49,7 @@ module Langfuse
       private
 
       def consume_active_hook
-        state_mutex.synchronize do
+        mutex.synchronize do
           active = @active
           @active = false
           active
@@ -57,16 +57,11 @@ module Langfuse
       end
 
       def reset_after_fork
-        @install_mutex = Mutex.new
-        @state_mutex = Mutex.new
+        @mutex = Mutex.new
       end
 
-      def install_mutex
-        @install_mutex ||= Mutex.new
-      end
-
-      def state_mutex
-        @state_mutex ||= Mutex.new
+      def mutex
+        @mutex ||= Mutex.new
       end
 
       def warn_failure(error)

--- a/spec/langfuse/exit_hook_spec.rb
+++ b/spec/langfuse/exit_hook_spec.rb
@@ -41,22 +41,17 @@ RSpec.describe Langfuse::ExitHook do
   end
 
   describe "fork safety" do
-    it "replaces inherited hook mutexes in a forked child" do
+    it "replaces the inherited hook mutex in a forked child" do
       skip "fork is not available" unless Process.respond_to?(:fork)
 
-      parent_install_mutex = described_class.send(:install_mutex)
-      parent_state_mutex = described_class.send(:state_mutex)
+      parent_mutex = described_class.send(:mutex)
       _child_pid, status, child_state = capture_forked_state do
-        {
-          install_mutex_replaced: !described_class.send(:install_mutex).equal?(parent_install_mutex),
-          state_mutex_replaced: !described_class.send(:state_mutex).equal?(parent_state_mutex)
-        }
+        { mutex_replaced: !described_class.send(:mutex).equal?(parent_mutex) }
       end
 
       expect(status).to be_success
-      expect(child_state).to eq(install_mutex_replaced: true, state_mutex_replaced: true)
-      expect(described_class.send(:install_mutex)).to equal(parent_install_mutex)
-      expect(described_class.send(:state_mutex)).to equal(parent_state_mutex)
+      expect(child_state).to eq(mutex_replaced: true)
+      expect(described_class.send(:mutex)).to equal(parent_mutex)
     end
   end
 end

--- a/spec/langfuse/exit_hook_spec.rb
+++ b/spec/langfuse/exit_hook_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Langfuse::ExitHook do
+  after do
+    described_class.enable
+  end
+
+  describe ".install!" do
+    it "registers one process callback" do
+      installed = described_class.instance_variable_get(:@installed)
+      described_class.instance_variable_set(:@installed, false)
+      allow(Kernel).to receive(:at_exit)
+
+      described_class.install!
+      described_class.install!
+
+      expect(Kernel).to have_received(:at_exit).once
+    ensure
+      described_class.instance_variable_set(:@installed, installed)
+    end
+  end
+
+  describe ".run" do
+    it "runs shutdown once" do
+      described_class.enable
+      expect(Langfuse).to receive(:shutdown).once
+
+      described_class.run
+      described_class.run
+    end
+
+    it "warns without raising when shutdown fails" do
+      described_class.enable
+      allow(Langfuse).to receive(:shutdown).and_raise(Langfuse::ApiError, "unavailable")
+      expect(Kernel).to receive(:warn).with(/Langfuse exit flush failed: Langfuse::ApiError - unavailable/)
+
+      expect { described_class.run }.not_to raise_error
+    end
+  end
+
+  describe "fork safety" do
+    it "replaces inherited hook mutexes in a forked child" do
+      skip "fork is not available" unless Process.respond_to?(:fork)
+
+      parent_install_mutex = described_class.send(:install_mutex)
+      parent_state_mutex = described_class.send(:state_mutex)
+      _child_pid, status, child_state = capture_forked_state do
+        {
+          install_mutex_replaced: !described_class.send(:install_mutex).equal?(parent_install_mutex),
+          state_mutex_replaced: !described_class.send(:state_mutex).equal?(parent_state_mutex)
+        }
+      end
+
+      expect(status).to be_success
+      expect(child_state).to eq(install_mutex_replaced: true, state_mutex_replaced: true)
+      expect(described_class.send(:install_mutex)).to equal(parent_install_mutex)
+      expect(described_class.send(:state_mutex)).to equal(parent_state_mutex)
+    end
+  end
+end

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -28,10 +28,19 @@ RSpec.describe Langfuse do
       expect(config1).to eq(config2)
     end
 
-    it "enables the process-exit callback" do
+    it "enables the process-exit callback when it builds a configuration" do
+      described_class.reset!
       expect(Langfuse::ExitHook).to receive(:enable).and_call_original
 
       described_class.configuration
+    end
+
+    it "does not re-enable the callback when it reads a cached configuration" do
+      configuration = described_class.configuration
+      Langfuse::ExitHook.disable
+      expect(Langfuse::ExitHook).not_to receive(:enable)
+
+      expect(described_class.configuration).to equal(configuration)
     end
   end
 

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Langfuse do
       config2 = described_class.configuration
       expect(config1).to eq(config2)
     end
+
+    it "enables the process-exit callback" do
+      expect(Langfuse::ExitHook).to receive(:enable).and_call_original
+
+      described_class.configuration
+    end
   end
 
   describe ".configure" do
@@ -179,6 +185,12 @@ RSpec.describe Langfuse do
   end
 
   describe ".reset!" do
+    it "disables the process-exit callback" do
+      expect(Langfuse::ExitHook).to receive(:disable).and_call_original
+
+      described_class.reset!
+    end
+
     it "resets configuration and client" do
       described_class.configure { |c| c.public_key = "test" }
       described_class.reset!
@@ -225,6 +237,7 @@ RSpec.describe Langfuse do
     end
 
     it "calls OtelSetup.shutdown with timeout" do
+      expect(Langfuse::ExitHook).to receive(:disable).and_call_original
       expect(Langfuse::OtelSetup).to receive(:shutdown).with(timeout: 30)
       described_class.shutdown
     end

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -42,6 +42,26 @@ RSpec.describe Langfuse do
 
       expect(described_class.configuration).to equal(configuration)
     end
+
+    it "starts a new client lifecycle when configuration is replaced" do
+      previous_client = described_class.client
+      described_class.shutdown
+      replacement = Langfuse::Config.new do |config|
+        config.public_key = "replacement_pk"
+        config.secret_key = "replacement_sk"
+      end
+      request = stub_request(:post, "https://cloud.langfuse.com/api/public/ingestion")
+                .to_return(status: 200, body: "", headers: {})
+
+      described_class.configuration = replacement
+      replacement_client = described_class.client
+      replacement_client.create_score(name: "quality", value: 1)
+      replacement_client.flush_scores
+
+      expect(replacement_client).not_to equal(previous_client)
+      expect(replacement_client.config).to equal(replacement)
+      expect(request).to have_been_requested.once
+    end
   end
 
   describe ".configure" do


### PR DESCRIPTION
#### `TL;DR`
Normal process exit now flushes queued Langfuse spans and scores automatically.

#### `Why`
Short-lived tasks and one-off scripts could exit before SDK background workers delivered pending telemetry.

#### `Checklist`
- [x] Has label
- [x] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)

Closes #

> [!NOTE]
> **Kade's words:**

## Summary

Normal process exit now flushes pending spans and scores. Applications do not need to register their own `at_exit` callback. Explicit `Langfuse.shutdown` and `Langfuse.reset!` disable the pending callback for the current lifecycle.

The callback runs once and catches shutdown errors. The callback inherits the fork-safe synchronization from the base PR. This PR targets the fork-safety branch so the unsafe exit-only behavior cannot land first.

### Change diagram

```mermaid
flowchart LR
    accTitle: Automatic telemetry flush during process exit
    accDescr: A normal process exit runs one SDK callback that flushes queued spans and scores without allowing errors to escape.
    E["Normal process exit"] --> H["Run one SDK callback"]
    H --> T["Flush pending spans"]
    H --> S["Flush pending scores"]
    H --> G["Catch shutdown errors"]
    X["Explicit SDK shutdown"] --> D["Disable pending callback"]
```

## Verification

I ran the complete RSpec suite locally. All 1,581 examples passed. Line coverage was 96.51%.

I ran RuboCop against 101 files. RuboCop reported no offenses.

I ran a separate Ruby process with the SDK and did not call `Langfuse.shutdown`. The process exited normally. The exit callback delivered trace `93999b473b9b9d18d22d0e1537004e64` and its queued `sdk-exit-hook` score. The Langfuse CLI read back both records.

I did not test abrupt termination because `SIGKILL` cannot run process-exit callbacks. I did not preview the rendered Mermaid diagram in GitHub. I reviewed the Mermaid source and syntax locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global process exit and configuration assignment behavior; failures are contained but every configured process now attempts shutdown on exit.
> 
> **Overview**
> Adds automatic flushing of pending spans and scores on **normal process exit**, so scripts and short-lived processes no longer need their own `at_exit { Langfuse.shutdown }`.
> 
> A new **`Langfuse::ExitHook`** registers a single `Kernel.at_exit` callback that runs `Langfuse.shutdown` once, swallows shutdown errors (warns instead), and resets its mutex after fork via **`ForkSafety`**. The hook is **enabled** when configuration is first built (`configuration` / `configuration=`) and **disabled** by explicit `Langfuse.shutdown` or `Langfuse.reset!` so double-flush is avoided. Assigning `configuration=` now calls `reset!` first and starts a fresh lifecycle.
> 
> **CONFIGURATION.md** documents the Process Exit behavior and updates the shutdown example away from manual `at_exit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f380f4853d53cb32d87f4f8d297e5e2f4fb942f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->