### PR TITLE
fix(scoring): bound score queue and batch payloads

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -266,6 +266,18 @@ Used by scoring API and OpenTelemetry tracing export. See [SCORING.md](SCORING.m
 config.flush_interval = 5  # Flush more frequently
 ```
 
+#### `score_queue_capacity`
+
+- **Type:** Integer
+- **Default:** `100000`
+- **Description:** Maximum number of asynchronous scores held in memory before new scores are dropped
+
+```ruby
+config.score_queue_capacity = 20_000
+```
+
+A full queue does not wait for capacity. The SDK logs an error and drops only the new asynchronous score. Synchronous `create_score!` calls do not use this queue. Flush requests remain below 2.5 MB when a batch contains more than one score. Failed batches stay queued in their original order for a later flush.
+
 #### `sample_rate`
 
 - **Type:** Float (`0.0..1.0`)
@@ -791,6 +803,7 @@ Client-readiness rules:
 - `public_key` and `secret_key` must be non-empty Strings
 - `base_url` must be an absolute HTTP or HTTPS URL
 - `batch_size` must be a positive Integer
+- `score_queue_capacity` must be a positive Integer
 - `flush_interval`, `timeout`, `cache_max_size`, `cache_lock_timeout`, and `cache_refresh_threads` must be positive numbers
 - `cache_ttl` must be a non-negative number
 - `cache_stale_ttl` must be a non-negative number or `:indefinite`

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -377,6 +377,7 @@ Scores are batched for efficiency:
 **Default settings:**
 - `batch_size`: 50 scores per batch
 - `flush_interval`: 10 seconds
+- `score_queue_capacity`: 100,000 pending asynchronous scores
 
 ```ruby
 # These scores are queued, not sent immediately
@@ -398,8 +399,11 @@ end
 Langfuse.configure do |config|
   config.batch_size = 100      # Larger batches
   config.flush_interval = 5    # More frequent flushes
+  config.score_queue_capacity = 20_000
 end
 ```
+
+The asynchronous queue is bounded. If the queue is full, the SDK logs an error, drops the new score, and returns without waiting for capacity. The SDK splits flush requests before a multi-score JSON payload exceeds 2.5 MB. A failed batch stays at the front of the queue for a later flush. Use `create_score!` when the caller needs synchronous delivery and an API error result.
 
 **Manual flush:**
 

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -29,6 +29,23 @@ module Langfuse
   # Raised when a Langfuse API request fails
   class ApiError < Error; end
 
+  # Describes whether a failed ingestion batch is safe to retry.
+  #
+  # @api private
+  class BatchDeliveryError < ApiError
+    # @param message [String] Delivery failure description
+    # @param retryable [Boolean] Whether the complete batch can be retried
+    def initialize(message, retryable:)
+      @retryable = retryable
+      super(message)
+    end
+
+    # @return [Boolean] whether the complete batch can be retried
+    def retryable?
+      @retryable
+    end
+  end
+
   # Raised when a requested resource is not found (HTTP 404)
   class NotFoundError < ApiError; end
 

--- a/lib/langfuse/api_client.rb
+++ b/lib/langfuse/api_client.rb
@@ -303,7 +303,7 @@ module Langfuse
       handle_batch_response(e.response)
     rescue Faraday::Error => e
       logger.error("Langfuse batch send failed: #{e.message}")
-      raise ApiError, "Batch send failed: #{e.message}"
+      raise BatchDeliveryError.new("Batch send failed: #{e.message}", retryable: true)
     end
 
     # Create a score through the synchronous Scores API.
@@ -818,7 +818,10 @@ module Langfuse
         raise UnauthorizedError, "Authentication failed. Check your API keys."
       else
         error_message = extract_error_message(response)
-        raise ApiError, "Batch send failed (#{response.status}): #{error_message}"
+        raise BatchDeliveryError.new(
+          "Batch send failed (#{response.status}): #{error_message}",
+          retryable: retryable_batch_status?(response.status)
+        )
       end
     end
 
@@ -831,7 +834,19 @@ module Langfuse
 
       messages = errors.filter_map { |e| e["message"] || e["error"] }
       summary = messages.empty? ? "#{errors.size} event(s) rejected" : messages.join("; ")
-      raise ApiError, "Batch send failed: #{summary}"
+      raise BatchDeliveryError.new(
+        "Batch send failed: #{summary}",
+        retryable: retryable_batch_errors?(errors)
+      )
+    end
+
+    def retryable_batch_errors?(errors)
+      statuses = errors.filter_map { |error| Integer(error["status"], exception: false) }
+      statuses.length == errors.length && statuses.all? { |status| retryable_batch_status?(status) }
+    end
+
+    def retryable_batch_status?(status)
+      status == 429 || status >= 500
     end
 
     # Extract error message from response body

--- a/lib/langfuse/config.rb
+++ b/lib/langfuse/config.rb
@@ -70,6 +70,9 @@ module Langfuse
     # @return [Integer] Interval in seconds to flush buffered events
     attr_accessor :flush_interval
 
+    # @return [Integer] Maximum number of asynchronous scores held in memory
+    attr_accessor :score_queue_capacity
+
     # @return [Symbol] Reserved no-op queue name for future async job integration
     attr_accessor :job_queue
 
@@ -148,6 +151,9 @@ module Langfuse
 
     # @return [Integer] Default flush interval in seconds
     DEFAULT_FLUSH_INTERVAL = 10
+
+    # @return [Integer] Default maximum number of queued asynchronous scores
+    DEFAULT_SCORE_QUEUE_CAPACITY = 100_000
 
     # @return [Symbol] Default ActiveJob queue name
     DEFAULT_JOB_QUEUE = :default
@@ -290,6 +296,7 @@ module Langfuse
       @tracing_async = DEFAULT_TRACING_ASYNC
       @batch_size = env_integer("LANGFUSE_FLUSH_AT") || DEFAULT_BATCH_SIZE
       @flush_interval = env_float("LANGFUSE_FLUSH_INTERVAL") || DEFAULT_FLUSH_INTERVAL
+      @score_queue_capacity = DEFAULT_SCORE_QUEUE_CAPACITY
       @job_queue = DEFAULT_JOB_QUEUE
     end
 
@@ -337,6 +344,10 @@ module Langfuse
       validate_non_negative_number!("cache_ttl", cache_ttl)
       validate_positive_number!("cache_max_size", cache_max_size)
       validate_positive_number!("cache_lock_timeout", cache_lock_timeout)
+      unless score_queue_capacity.is_a?(Integer) && score_queue_capacity.positive?
+        raise ConfigurationError, "score_queue_capacity must be a positive Integer"
+      end
+
       validate_swr_config!
       validate_cache_backend!
     end

--- a/lib/langfuse/pending_score_queue.rb
+++ b/lib/langfuse/pending_score_queue.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Langfuse
+  # Thread-safe bounded queue that keeps scores until delivery succeeds.
+  #
+  # @api private
+  class PendingScoreQueue
+    # @return [Integer] Maximum number of pending scores
+    attr_reader :capacity
+
+    # @param capacity [Integer] Maximum number of pending scores
+    def initialize(capacity:)
+      @capacity = capacity
+      @events = []
+      @mutex = Mutex.new
+    end
+
+    # Add an event without waiting for queue capacity.
+    #
+    # @param event [Hash] Score ingestion event
+    # @return [Boolean] true when accepted, false when full
+    def push(event)
+      @mutex.synchronize do
+        return false if @events.length >= capacity
+
+        @events << event
+        true
+      end
+    end
+
+    # @return [Array<Hash>] Stable copy of pending events in insertion order
+    def snapshot
+      @mutex.synchronize { @events.dup }
+    end
+
+    # Remove a delivered prefix while preserving newer events.
+    #
+    # @param count [Integer] Number of delivered events
+    # @return [void]
+    def remove_prefix(count)
+      @mutex.synchronize { @events.shift(count) }
+    end
+
+    # @return [Integer] Number of pending events
+    def size
+      @mutex.synchronize { @events.size }
+    end
+
+    # @return [Boolean] true when no events are pending
+    def empty?
+      @mutex.synchronize { @events.empty? }
+    end
+  end
+end

--- a/lib/langfuse/pending_score_queue.rb
+++ b/lib/langfuse/pending_score_queue.rb
@@ -33,6 +33,14 @@ module Langfuse
       @mutex.synchronize { @events.dup }
     end
 
+    # Return up to limit events from the front without removing them.
+    #
+    # @param limit [Integer] Maximum number of events to return
+    # @return [Array<Hash>] Stable copy of the pending prefix
+    def first(limit)
+      @mutex.synchronize { @events.first(limit) }
+    end
+
     # Remove a delivered prefix while preserving newer events.
     #
     # @param count [Integer] Number of delivered events

--- a/lib/langfuse/score_client.rb
+++ b/lib/langfuse/score_client.rb
@@ -434,7 +434,7 @@ module Langfuse
 
       discard_batch(events, e)
     rescue UnauthorizedError => e
-      discard_batch(events, e)
+      retry_batch(e)
     rescue StandardError => e
       logger.error("Langfuse score batch send failed: #{e.message}")
       :retry

--- a/lib/langfuse/score_client.rb
+++ b/lib/langfuse/score_client.rb
@@ -334,7 +334,7 @@ module Langfuse
       data_type_str = Types::SCORE_DATA_TYPES[data_type] || raise(ArgumentError, "Invalid data_type: #{data_type}")
       validate_correction_subject!(data_type:, trace_id:, session_id:, dataset_run_id:, config_id:)
 
-      {
+      snapshot_score_body(
         id: id || SecureRandom.uuid,
         name: name,
         value: normalized_value,
@@ -347,9 +347,16 @@ module Langfuse
         environment: environment || config.environment,
         datasetRunId: dataset_run_id,
         configId: config_id
-      }.compact
+      )
     end
     # rubocop:enable Metrics/ParameterLists
+
+    # Snapshot the wire body so caller mutation cannot poison the pending queue.
+    def snapshot_score_body(attributes)
+      JSON.parse(JSON.generate(attributes.compact), symbolize_names: true)
+    rescue JSON::JSONError => e
+      raise ArgumentError, "Score data must be JSON-serializable: #{e.message}"
+    end
 
     def build_score_event(score)
       { id: SecureRandom.uuid, type: "score-create", timestamp: Time.now.utc.iso8601(3), body: score }

--- a/lib/langfuse/score_client.rb
+++ b/lib/langfuse/score_client.rb
@@ -285,7 +285,10 @@ module Langfuse
     def flush_pending_batches
       loop do
         batch = next_batch
-        break if batch.empty? || !send_batch(batch)
+        break if batch.empty?
+
+        delivery = send_batch(batch)
+        break if delivery == :retry
 
         @queue.remove_prefix(batch.length)
       end
@@ -415,13 +418,31 @@ module Langfuse
     # Send a batch of events to the API
     #
     # @param events [Array<Hash>] Array of event hashes
-    # @return [Boolean] true when delivered, false when delivery fails
+    # @return [Symbol] :delivered, :discarded, or :retry
     def send_batch(events)
       api_client.send_batch(events)
-      true
+      :delivered
+    rescue BatchDeliveryError => e
+      return retry_batch(e) if e.retryable?
+
+      discard_batch(events, e)
+    rescue UnauthorizedError => e
+      discard_batch(events, e)
     rescue StandardError => e
       logger.error("Langfuse score batch send failed: #{e.message}")
-      false
+      :retry
+    end
+
+    def retry_batch(error)
+      logger.error("Langfuse score batch send failed and will retry: #{error.message}")
+      :retry
+    end
+
+    def discard_batch(events, error)
+      logger.error(
+        "Langfuse dropped #{events.length} score event(s) after a permanent batch failure: #{error.message}"
+      )
+      :discarded
     end
 
     # Start the background flush timer thread

--- a/lib/langfuse/score_client.rb
+++ b/lib/langfuse/score_client.rb
@@ -37,7 +37,7 @@ module Langfuse
     HEX_TRACE_ID_PATTERN = /\A[0-9a-f]{32}\z/
     MAX_BATCH_PAYLOAD_BYTES = 2_500_000
     EMPTY_BATCH_PAYLOAD_BYTES = JSON.generate(batch: []).bytesize
-    private_constant :EMPTY_BATCH_PAYLOAD_BYTES
+    private_constant :MAX_BATCH_PAYLOAD_BYTES, :EMPTY_BATCH_PAYLOAD_BYTES
 
     # Initialize a new ScoreClient
     #
@@ -283,36 +283,28 @@ module Langfuse
     end
 
     def flush_pending_batches
-      events = @queue.snapshot
-      return if events.empty?
-
-      split_batches(events).each do |batch|
-        break unless send_batch(batch)
+      loop do
+        batch = next_batch
+        break if batch.empty? || !send_batch(batch)
 
         @queue.remove_prefix(batch.length)
       end
     end
 
-    def split_batches(events)
-      batches = []
-      current_batch = []
-      current_bytes = EMPTY_BATCH_PAYLOAD_BYTES
+    def next_batch
+      batch = []
+      payload_bytes = EMPTY_BATCH_PAYLOAD_BYTES
 
-      events.each do |event|
+      @queue.first(config.batch_size).each do |event|
         event_json = JSON.generate(event)
-        additional_bytes = event_json.bytesize + (current_batch.empty? ? 0 : 1)
-        if current_batch.any? && current_bytes + additional_bytes > MAX_BATCH_PAYLOAD_BYTES
-          batches << current_batch
-          current_batch = []
-          current_bytes = EMPTY_BATCH_PAYLOAD_BYTES
-          additional_bytes = event_json.bytesize
-        end
-        current_batch << event
-        current_bytes += additional_bytes
+        additional_bytes = event_json.bytesize + (batch.empty? ? 0 : 1)
+        break if batch.any? && payload_bytes + additional_bytes > MAX_BATCH_PAYLOAD_BYTES
+
+        batch << event
+        payload_bytes += additional_bytes
       end
 
-      batches << current_batch unless current_batch.empty?
-      batches
+      batch
     end
 
     # Validate score inputs and build the canonical API body.

--- a/lib/langfuse/score_client.rb
+++ b/lib/langfuse/score_client.rb
@@ -2,7 +2,9 @@
 
 require "securerandom"
 require "opentelemetry/trace"
+require "json"
 require_relative "fork_safety"
+require_relative "pending_score_queue"
 
 module Langfuse
   # Client for creating and batching Langfuse scores
@@ -33,6 +35,9 @@ module Langfuse
     attr_reader :logger
 
     HEX_TRACE_ID_PATTERN = /\A[0-9a-f]{32}\z/
+    MAX_BATCH_PAYLOAD_BYTES = 2_500_000
+    EMPTY_BATCH_PAYLOAD_BYTES = JSON.generate(batch: []).bytesize
+    private_constant :EMPTY_BATCH_PAYLOAD_BYTES
 
     # Initialize a new ScoreClient
     #
@@ -42,8 +47,9 @@ module Langfuse
       @api_client = api_client
       @config = config
       @logger = config.logger
-      @queue = Queue.new
-      @mutex = Mutex.new
+      @queue = PendingScoreQueue.new(capacity: config.score_queue_capacity)
+      @shutdown_mutex = Mutex.new
+      @flush_mutex = Mutex.new
       @flush_thread = nil
       @shutdown = false
       # Match the immutable tracing setup contract: once this client exists, later config
@@ -106,8 +112,7 @@ module Langfuse
 
       return unless enqueue_trace_linked_score?(trace_id)
 
-      @queue << build_score_event(score)
-      flush if @queue.size >= config.batch_size
+      enqueue_score_event(build_score_event(score))
     rescue StandardError => e
       logger.error("Langfuse score creation failed: #{e.message}")
       raise
@@ -232,19 +237,7 @@ module Langfuse
     #
     # @return [void]
     def flush
-      return if @queue.empty?
-
-      events = []
-      @queue.size.times do
-        events << @queue.pop(true)
-      rescue StandardError
-        nil
-      end
-      events.compact!
-
-      return if events.empty?
-
-      send_batch(events)
+      @flush_mutex.synchronize { flush_pending_batches }
     rescue StandardError => e
       logger.error("Langfuse score flush failed: #{e.message}")
       # Don't raise - silent error handling for batch operations
@@ -256,7 +249,7 @@ module Langfuse
     #
     # @return [void]
     def shutdown
-      @mutex.synchronize do
+      @shutdown_mutex.synchronize do
         return if @shutdown
 
         @shutdown = true
@@ -270,11 +263,56 @@ module Langfuse
     # Discard parent-owned queued work and restore the child process timer.
     def reset_after_fork
       inherited_shutdown = @shutdown
-      @queue = Queue.new
-      @mutex = Mutex.new
+      @queue = PendingScoreQueue.new(capacity: config.score_queue_capacity)
+      @shutdown_mutex = Mutex.new
+      @flush_mutex = Mutex.new
       @flush_thread = nil
       @shutdown = inherited_shutdown
       start_flush_timer unless @shutdown
+    end
+
+    def enqueue_score_event(event)
+      unless @queue.push(event)
+        logger.error(
+          "Langfuse score queue is full (capacity=#{@queue.capacity}); dropping new asynchronous score"
+        )
+        return
+      end
+
+      flush if @queue.size >= config.batch_size
+    end
+
+    def flush_pending_batches
+      events = @queue.snapshot
+      return if events.empty?
+
+      split_batches(events).each do |batch|
+        break unless send_batch(batch)
+
+        @queue.remove_prefix(batch.length)
+      end
+    end
+
+    def split_batches(events)
+      batches = []
+      current_batch = []
+      current_bytes = EMPTY_BATCH_PAYLOAD_BYTES
+
+      events.each do |event|
+        event_json = JSON.generate(event)
+        additional_bytes = event_json.bytesize + (current_batch.empty? ? 0 : 1)
+        if current_batch.any? && current_bytes + additional_bytes > MAX_BATCH_PAYLOAD_BYTES
+          batches << current_batch
+          current_batch = []
+          current_bytes = EMPTY_BATCH_PAYLOAD_BYTES
+          additional_bytes = event_json.bytesize
+        end
+        current_batch << event
+        current_bytes += additional_bytes
+      end
+
+      batches << current_batch unless current_batch.empty?
+      batches
     end
 
     # Validate score inputs and build the canonical API body.
@@ -385,12 +423,13 @@ module Langfuse
     # Send a batch of events to the API
     #
     # @param events [Array<Hash>] Array of event hashes
-    # @return [void]
+    # @return [Boolean] true when delivered, false when delivery fails
     def send_batch(events)
       api_client.send_batch(events)
+      true
     rescue StandardError => e
       logger.error("Langfuse score batch send failed: #{e.message}")
-      # Don't raise - silent error handling
+      false
     end
 
     # Start the background flush timer thread

--- a/spec/langfuse/api_client_spec.rb
+++ b/spec/langfuse/api_client_spec.rb
@@ -1422,7 +1422,9 @@ RSpec.describe Langfuse::ApiClient do
 
         expect do
           api_client.send_batch(events)
-        end.to raise_error(Langfuse::ApiError, /name is required/)
+        end.to raise_error(Langfuse::BatchDeliveryError, /name is required/) { |error|
+          expect(error).not_to be_retryable
+        }
       end
 
       it "raises ApiError for a 200 status whose body still lists errors" do
@@ -1509,7 +1511,9 @@ RSpec.describe Langfuse::ApiClient do
 
         expect do
           api_client.send_batch(events)
-        end.to raise_error(Langfuse::ApiError, /Batch send failed/)
+        end.to raise_error(Langfuse::BatchDeliveryError, /Batch send failed/) { |error|
+          expect(error).to be_retryable
+        }
       end
 
       it "handles network errors" do

--- a/spec/langfuse/config_spec.rb
+++ b/spec/langfuse/config_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Langfuse::Config do
       expect(config.cache_stale_while_revalidate).to be false
       expect(config.cache_stale_ttl).to eq(0) # Defaults to 0 (SWR disabled)
       expect(config.cache_refresh_threads).to eq(5)
+      expect(config.score_queue_capacity).to eq(100_000)
       expect(config.should_export_span).to be_nil
       expect(config.sample_rate).to eq(1.0)
     end
@@ -179,6 +180,7 @@ RSpec.describe Langfuse::Config do
         cache_stale_ttl
         cache_refresh_threads
         flush_interval
+        score_queue_capacity
       ]
 
       numeric_settings.product(invalid_values).each do |setting, value|
@@ -354,6 +356,15 @@ RSpec.describe Langfuse::Config do
         expect { config.validate! }.to raise_error(
           Langfuse::ConfigurationError,
           "flush_interval must be positive"
+        )
+      end
+
+      it "raises ConfigurationError when score_queue_capacity is not a positive Integer" do
+        config.score_queue_capacity = 0
+
+        expect { config.validate! }.to raise_error(
+          Langfuse::ConfigurationError,
+          "score_queue_capacity must be a positive Integer"
         )
       end
     end
@@ -714,6 +725,11 @@ RSpec.describe Langfuse::Config do
     it "allows setting timeout" do
       config.timeout = 10
       expect(config.timeout).to eq(10)
+    end
+
+    it "allows setting score_queue_capacity" do
+      config.score_queue_capacity = 2_000
+      expect(config.score_queue_capacity).to eq(2_000)
     end
 
     it "allows setting cache_ttl" do

--- a/spec/langfuse/pending_score_queue_spec.rb
+++ b/spec/langfuse/pending_score_queue_spec.rb
@@ -29,4 +29,15 @@ RSpec.describe Langfuse::PendingScoreQueue do
     expect(queue.snapshot).to eq([{ id: 2 }])
     expect(queue).not_to be_empty
   end
+
+  it "returns a stable limited prefix" do
+    queue.push({ id: 1 })
+    queue.push({ id: 2 })
+
+    prefix = queue.first(1)
+    queue.remove_prefix(1)
+
+    expect(prefix).to eq([{ id: 1 }])
+    expect(queue.snapshot).to eq([{ id: 2 }])
+  end
 end

--- a/spec/langfuse/pending_score_queue_spec.rb
+++ b/spec/langfuse/pending_score_queue_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Langfuse::PendingScoreQueue do
+  subject(:queue) { described_class.new(capacity: 2) }
+
+  it "accepts events up to its capacity without mutating the input snapshot" do
+    expect(queue.push({ id: 1 })).to be true
+    snapshot = queue.snapshot
+    expect(queue.push({ id: 2 })).to be true
+
+    expect(snapshot).to eq([{ id: 1 }])
+    expect(queue.size).to eq(2)
+  end
+
+  it "rejects a new event when full" do
+    queue.push({ id: 1 })
+    queue.push({ id: 2 })
+
+    expect(queue.push({ id: 3 })).to be false
+    expect(queue.snapshot).to eq([{ id: 1 }, { id: 2 }])
+  end
+
+  it "removes only a delivered prefix" do
+    queue.push({ id: 1 })
+    queue.push({ id: 2 })
+
+    queue.remove_prefix(1)
+
+    expect(queue.snapshot).to eq([{ id: 2 }])
+    expect(queue).not_to be_empty
+  end
+end

--- a/spec/langfuse/score_client_spec.rb
+++ b/spec/langfuse/score_client_spec.rb
@@ -810,6 +810,19 @@ RSpec.describe Langfuse::ScoreClient do
       expect(score_client.instance_variable_get(:@queue)).to be_empty
     end
 
+    it "caps each request at the configured batch size" do
+      allow(api_client).to receive(:send_batch)
+      3.times { |index| score_client.create(name: "score-#{index}", value: index) }
+      config.batch_size = 2
+      sent_batches = []
+      allow(api_client).to receive(:send_batch) { |batch| sent_batches << batch }
+
+      score_client.flush
+
+      expect(sent_batches.map(&:length)).to eq([2, 1])
+      expect(sent_batches.flatten.map { |event| event.dig(:body, :name) }).to eq(%w[score-0 score-1 score-2])
+    end
+
     it "keeps a failed batch and later scores queued in their original order" do
       3.times { |index| score_client.create(name: "score-#{index}", value: index) }
       pending_queue = score_client.instance_variable_get(:@queue)

--- a/spec/langfuse/score_client_spec.rb
+++ b/spec/langfuse/score_client_spec.rb
@@ -797,6 +797,35 @@ RSpec.describe Langfuse::ScoreClient do
       score_client.flush
     end
 
+    it "rejects unserializable scores before they enter the queue" do
+      expect do
+        score_client.create(name: "invalid", value: Float::NAN)
+      end.to raise_error(ArgumentError, /Score data must be JSON-serializable/)
+      expect(api_client).to receive(:send_batch).with([
+                                                        hash_including(body: hash_including(name: "valid"))
+                                                      ])
+
+      score_client.create(name: "valid", value: 1)
+      score_client.flush
+
+      expect(score_client.instance_variable_get(:@queue)).to be_empty
+    end
+
+    it "snapshots caller-owned metadata before enqueue" do
+      metadata = { nested: { value: "before" } }
+      expect(api_client).to receive(:send_batch).with([
+                                                        hash_including(
+                                                          body: hash_including(
+                                                            metadata: { nested: { value: "before" } }
+                                                          )
+                                                        )
+                                                      ])
+
+      score_client.create(name: "quality", value: 1, metadata: metadata)
+      metadata[:nested][:value] = "after"
+      score_client.flush
+    end
+
     it "handles API errors silently" do
       allow(api_client).to receive(:send_batch).and_raise(Langfuse::ApiError, "API error")
 

--- a/spec/langfuse/score_client_spec.rb
+++ b/spec/langfuse/score_client_spec.rb
@@ -793,6 +793,68 @@ RSpec.describe Langfuse::ScoreClient do
         score_client.flush
       end.not_to raise_error
     end
+
+    it "splits requests before a multi-score payload exceeds the byte limit" do
+      allow(api_client).to receive(:send_batch)
+      3.times { |index| score_client.create(name: "score-#{index}", value: index) }
+      pending_events = score_client.instance_variable_get(:@queue).snapshot
+      single_event_bytes = JSON.generate(batch: [pending_events.first]).bytesize
+      stub_const("Langfuse::ScoreClient::MAX_BATCH_PAYLOAD_BYTES", single_event_bytes)
+      sent_batches = []
+      allow(api_client).to receive(:send_batch) { |batch| sent_batches << batch }
+
+      score_client.flush
+
+      expect(sent_batches.length).to eq(3)
+      expect(sent_batches.flatten.map { |event| event.dig(:body, :name) }).to eq(%w[score-0 score-1 score-2])
+      expect(score_client.instance_variable_get(:@queue)).to be_empty
+    end
+
+    it "keeps a failed batch and later scores queued in their original order" do
+      3.times { |index| score_client.create(name: "score-#{index}", value: index) }
+      pending_queue = score_client.instance_variable_get(:@queue)
+      single_event_bytes = JSON.generate(batch: [pending_queue.snapshot.first]).bytesize
+      stub_const("Langfuse::ScoreClient::MAX_BATCH_PAYLOAD_BYTES", single_event_bytes)
+      attempts = []
+      allow(api_client).to receive(:send_batch) do |batch|
+        attempts << batch.map { |event| event.dig(:body, :name) }
+        raise Langfuse::ApiError, "unavailable" if attempts.length == 2
+      end
+
+      score_client.flush
+
+      expect(attempts).to eq([%w[score-0], %w[score-1]])
+      expect(pending_queue.snapshot.map { |event| event.dig(:body, :name) }).to eq(%w[score-1 score-2])
+
+      retried_names = []
+      allow(api_client).to receive(:send_batch) do |batch|
+        retried_names.concat(batch.map { |event| event.dig(:body, :name) })
+      end
+      score_client.flush
+
+      expect(retried_names).to eq(%w[score-1 score-2])
+      expect(pending_queue).to be_empty
+    end
+  end
+
+  describe "queue capacity" do
+    before do
+      config.score_queue_capacity = 1
+      allow(api_client).to receive(:send_batch)
+    end
+
+    it "drops only the new score without blocking when the queue is full" do
+      score_client.create(name: "accepted", value: 1)
+      expect(config.logger).to receive(:error).with(
+        "Langfuse score queue is full (capacity=1); dropping new asynchronous score"
+      )
+
+      enqueue_thread = Thread.new { score_client.create(name: "dropped", value: 2) }
+
+      expect(enqueue_thread.join(1)).to equal(enqueue_thread)
+      pending_names = score_client.instance_variable_get(:@queue).snapshot.map { |event| event.dig(:body, :name) }
+      expect(pending_names).to eq(["accepted"])
+    end
   end
 
   describe "#shutdown" do

--- a/spec/langfuse/score_client_spec.rb
+++ b/spec/langfuse/score_client_spec.rb
@@ -907,6 +907,32 @@ RSpec.describe Langfuse::ScoreClient do
       expect(score_client.instance_variable_get(:@queue)).to be_empty
     end
 
+    it "stops after an authentication failure and keeps all scores queued" do
+      attempts = []
+      authentication_fails = true
+      allow(api_client).to receive(:send_batch) do |batch|
+        attempts << batch.first.dig(:body, :name)
+        if authentication_fails
+          authentication_fails = false
+          raise Langfuse::UnauthorizedError, "invalid credentials"
+        end
+      end
+
+      score_client.create(name: "score-0", value: 0)
+      score_client.create(name: "score-1", value: 1)
+      config.batch_size = 1
+      score_client.flush
+
+      pending_queue = score_client.instance_variable_get(:@queue)
+      expect(attempts).to eq(["score-0"])
+      expect(pending_queue.snapshot.map { |event| event.dig(:body, :name) }).to eq(%w[score-0 score-1])
+
+      score_client.flush
+
+      expect(attempts).to eq(%w[score-0 score-0 score-1])
+      expect(pending_queue).to be_empty
+    end
+
     it "keeps transient batch failures queued for a later retry" do
       allow(api_client).to receive(:send_batch).and_raise(
         Langfuse::BatchDeliveryError.new("unavailable", retryable: true)

--- a/spec/langfuse/score_client_spec.rb
+++ b/spec/langfuse/score_client_spec.rb
@@ -23,6 +23,25 @@ RSpec.describe Langfuse::ScoreClient do
       .to_return(status: 200, body: "", headers: {})
   end
 
+  def capture_child_score_state(score_client, parent_queue:, parent_mutexes:)
+    capture_forked_state do
+      score_client.create(name: "child-score", value: 1)
+      child_queue = score_client.instance_variable_get(:@queue)
+      child_mutexes = %i[@shutdown_mutex @flush_mutex].map { |name| score_client.instance_variable_get(name) }
+      child_thread = score_client.instance_variable_get(:@flush_thread)
+      score_client.flush
+      {
+        pid: Process.pid,
+        queue_replaced: !child_queue.equal?(parent_queue),
+        queue_class: child_queue.class.name,
+        queue_capacity: child_queue.capacity,
+        queue_empty_after_flush: child_queue.empty?,
+        mutexes_replaced: child_mutexes.zip(parent_mutexes).all? { |child, parent| !child.equal?(parent) },
+        timer_alive: child_thread&.alive?
+      }
+    end
+  end
+
   after do
     score_client.shutdown
   end
@@ -50,24 +69,17 @@ RSpec.describe Langfuse::ScoreClient do
       score_client.create(name: "parent-score", value: 1)
       parent_queue = score_client.instance_variable_get(:@queue)
       parent_thread = score_client.instance_variable_get(:@flush_thread)
-      child_pid, status, child_state = capture_forked_state do
-        score_client.create(name: "child-score", value: 1)
-        child_queue = score_client.instance_variable_get(:@queue)
-        child_thread = score_client.instance_variable_get(:@flush_thread)
-        score_client.flush
-        {
-          pid: Process.pid,
-          queue_replaced: !child_queue.equal?(parent_queue),
-          queue_empty_after_flush: child_queue.empty?,
-          timer_alive: child_thread&.alive?
-        }
-      end
+      parent_mutexes = %i[@shutdown_mutex @flush_mutex].map { |name| score_client.instance_variable_get(name) }
+      child_pid, status, child_state = capture_child_score_state(score_client, parent_queue:, parent_mutexes:)
 
       expect(status).to be_success
       expect(child_state).to eq(
         pid: child_pid,
         queue_replaced: true,
+        queue_class: "Langfuse::PendingScoreQueue",
+        queue_capacity: Langfuse::Config::DEFAULT_SCORE_QUEUE_CAPACITY,
         queue_empty_after_flush: true,
+        mutexes_replaced: true,
         timer_alive: true
       )
       expect(score_client.instance_variable_get(:@queue)).to equal(parent_queue)
@@ -847,6 +859,35 @@ RSpec.describe Langfuse::ScoreClient do
 
       expect(retried_names).to eq(%w[score-1 score-2])
       expect(pending_queue).to be_empty
+    end
+
+    it "drops a permanently rejected batch and continues with later scores" do
+      config.batch_size = 1
+      attempts = []
+      allow(api_client).to receive(:send_batch) do |batch|
+        name = batch.first.dig(:body, :name)
+        attempts << name
+        raise Langfuse::BatchDeliveryError.new("name is invalid", retryable: false) if name == "invalid"
+      end
+
+      score_client.create(name: "invalid", value: 1)
+      score_client.create(name: "valid", value: 2)
+      score_client.flush
+
+      expect(attempts).to eq(%w[invalid valid])
+      expect(score_client.instance_variable_get(:@queue)).to be_empty
+    end
+
+    it "keeps transient batch failures queued for a later retry" do
+      allow(api_client).to receive(:send_batch).and_raise(
+        Langfuse::BatchDeliveryError.new("unavailable", retryable: true)
+      )
+
+      score_client.create(name: "retry-me", value: 1)
+      score_client.flush
+
+      pending_names = score_client.instance_variable_get(:@queue).snapshot.map { |event| event.dig(:body, :name) }
+      expect(pending_names).to eq(["retry-me"])
     end
   end
 


### PR DESCRIPTION
#### `TL;DR`
Asynchronous score batching now bounds memory use and limits multi-score request size.

#### `Why`
An ingestion outage could grow the score queue without a limit. Large flushes could also exceed the ingestion request limit.

#### `Checklist`
- [x] Has label
- [x] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)

Closes #

> [!NOTE]
> **Kade's words:**

## Summary

Asynchronous score batching now keeps at most 100,000 pending scores by default. Applications can set `score_queue_capacity`. A full queue logs an error and drops the new asynchronous score without waiting for capacity. Synchronous score creation stays unchanged.

Flushes split before a multi-score JSON payload exceeds 2.5 MB. Delivered batches leave the queue. A failed batch and all later scores stay queued in their original order. This design keeps retry memory bounded.

### Change diagram

```mermaid
flowchart TD
    accTitle: Bounded asynchronous score delivery
    accDescr: New scores enter a bounded queue. Flushes send size-limited batches and retain failed work in order.
    C["Create asynchronous score"] --> Q{"Queue has capacity"}
    Q -->|"No"| D["Log error and drop new score"]
    Q -->|"Yes"| A["Append score"]
    A --> B["Build payload below 2.5 MB"]
    B --> S{"Batch delivery succeeds"}
    S -->|"Yes"| R["Remove delivered prefix"]
    S -->|"No"| K["Keep failed batch in order"]
```

## Verification

I ran the complete RSpec suite locally. All 1,578 examples passed. Line coverage was 97.33%.

I ran RuboCop against 98 files. RuboCop reported no offenses.

I ran a live Ruby SDK probe with a forced small payload limit. The SDK sent six accepted scores in six separate ingestion requests for trace `b30020337050ed408b8f27469c4b4d2c`. The Langfuse CLI read back the trace and all six score names.

I did not send a production-sized 2.5 MB payload to Langfuse. Unit tests validate exact JSON byte accounting at the split boundary. I did not preview the rendered Mermaid diagram in GitHub. I reviewed the Mermaid source and syntax locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async score delivery, drop-on-full, and retry/discard semantics—scores can be lost under overload or permanent API rejection, though behavior is documented and heavily tested.
> 
> **Overview**
> Asynchronous score batching is now **memory-bounded** and **safer under API failures**. Apps can set `score_queue_capacity` (default **100,000**); when the queue is full the SDK **logs and drops only the new** async score—no blocking. Sync `create_score!` is unchanged.
> 
> **Flush behavior** replaces draining the whole unbounded queue with ordered prefix delivery: multi-score requests are **split before ~2.5 MB** JSON; successful prefixes are removed; **retryable** failures (429/5xx, network, auth) leave the failed batch at the front; **non-retryable** batch errors drop that batch and continue. Score bodies are **JSON-snapshotted** at enqueue so caller mutation cannot corrupt pending events.
> 
> Ingestion batch failures now raise **`BatchDeliveryError`** with a `retryable?` flag instead of generic `ApiError` where appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a767bbb41b99eb56bc223dc5285ccec1c7e103c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->