### PR TITLE
fix(security): resolve dependency alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,10 @@ PATH
   specs:
     langfuse-rb (0.11.0)
       base64 (~> 0.2)
-      concurrent-ruby (~> 1.2)
-      faraday (>= 1.0, < 3)
+      concurrent-ruby (>= 1.3.7, < 2.0)
+      faraday (>= 2.14.3, < 3)
       faraday-retry (>= 1.0, < 3.0)
+      json (~> 2.19, >= 2.19.9)
       mustache (~> 1.1)
       opentelemetry-api (~> 1.2)
       opentelemetry-common (~> 0.21)
@@ -20,14 +21,14 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (3.3.1)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     crack (1.0.0)
       bigdecimal
       rexml
     diff-lcs (1.6.2)
     docile (1.4.1)
     dotenv (2.8.1)
-    faraday (2.14.1)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -41,7 +42,7 @@ GEM
     googleapis-common-protos-types (1.22.0)
       google-protobuf (~> 4.26)
     hashdiff (1.2.1)
-    json (2.19.3)
+    json (2.21.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/langfuse.gemspec
+++ b/langfuse.gemspec
@@ -29,12 +29,19 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Runtime dependencies - HTTP & Templating
-  spec.add_dependency "faraday", ">= 1.0", "< 3"
+  # faraday floor raised to 2.14.3 to exclude CVE-2026-33637 and CVE-2026-54297.
+  # This drops Faraday 1.x support; Faraday 2.x needs Ruby >= 3.0, satisfied by our >= 3.2.0 floor.
+  spec.add_dependency "faraday", ">= 2.14.3", "< 3"
   spec.add_dependency "faraday-retry", ">= 1.0", "< 3.0"
   spec.add_dependency "mustache", "~> 1.1"
+  # json is used directly at runtime (api_client, read_api, score_client) and was only
+  # constrained transitively via faraday. Declared explicitly with a >= 2.19.9 floor so
+  # consumers cannot resolve json affected by CVE-2026-54696.
+  spec.add_dependency "json", "~> 2.19", ">= 2.19.9"
 
   # Runtime dependencies - Concurrency (for SWR caching)
-  spec.add_dependency "concurrent-ruby", "~> 1.2"
+  # concurrent-ruby floor raised to 1.3.7 to exclude CVE-2026-54904/54905/54906.
+  spec.add_dependency "concurrent-ruby", ">= 1.3.7", "< 2.0"
 
   # Runtime dependencies - OpenTelemetry (for tracing)
   spec.add_dependency "opentelemetry-api", "~> 1.2"

--- a/spec/langfuse/span_processor_spec.rb
+++ b/spec/langfuse/span_processor_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Langfuse::SpanProcessor do
       span.finish
       span_data = exported_spans_by_name.fetch("generation")
       otlp_exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(
-        endpoint: "http://localhost/api/public/otel/v1/traces"
+        endpoint: "https://localhost/api/public/otel/v1/traces"
       )
 
       expect(otlp_exporter.send(:encode, [span_data])).to be_a(String)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### `TL;DR`
Patch the open langfuse-rb security alerts. Raise runtime dependency floors so gem consumers cannot select vulnerable versions.

#### `Why`
Open alerts affect Faraday, concurrent-ruby, and json. A lockfile-only bump does not protect downstream gem consumers. The gemspec must also exclude the vulnerable versions.


### Summary
This gem now rejects known-vulnerable Faraday, concurrent-ruby, and json versions at the gemspec level. Consumers can no longer resolve a vulnerable runtime version. The fix updates the gemspec and the lockfile together.

- Faraday. Floor raised to `>= 2.14.3, < 3`. This excludes CVE-2026-33637 and CVE-2026-54297. Faraday 1.x support is dropped. Faraday 2.x needs Ruby >= 3.0. The gem keeps Ruby >= 3.2.0. So the tradeoff is safe.
- concurrent-ruby. Floor raised to `>= 1.3.7, < 2.0`. This excludes CVE-2026-54904, CVE-2026-54905, and CVE-2026-54906.
- json. Promoted to an explicit runtime dependency `~> 2.19, >= 2.19.9`. json is used directly at runtime (`api_client`, `read_api`, `score_client`) but was constrained only through Faraday. This excludes CVE-2026-54696.
- Lock result. `faraday 2.14.3`, `concurrent-ruby 1.3.8`, `json 2.21.2`. `bundler-audit` then reports no vulnerabilities.
- Test-only insecure endpoint. The OTLP encode test used an `http://` URL. It now uses `https://`. The test calls only `encode`. It sends no request. No network behavior is added.
- diff-lcs multi-license alert. See the policy note below the diagram.

### Change diagram

```mermaid
graph TD
  accTitle: Patched dependency constraints
  accDescr: The SDK moves from vulnerable locked dependencies to patched runtime constraints.
  subgraph Before["Before (vulnerable)"]
    B1["faraday 2.14.1"]
    B2["concurrent-ruby 1.3.6"]
    B3["json 2.19.3 (transitive only)"]
  end
  subgraph After["After (patched and constrained)"]
    A1["faraday >= 2.14.3, < 3"]
    A2["concurrent-ruby >= 1.3.7, < 2.0"]
    A3["json ~> 2.19, >= 2.19.9 (explicit runtime dep)"]
  end
  B1 -->|"CVE-2026-33637 / 54297"| A1
  B2 -->|"CVE-2026-54904 / 54905 / 54906"| A2
  B3 -->|"CVE-2026-54696"| A3
```

**diff-lcs multi-license — evidence and decision.**
diff-lcs is a test-only dependency. It arrives through `rspec-expectations` and `rspec-mocks`. The gemspec `files` list ships only `lib/`, `README`, `LICENSE`, and `CHANGELOG`. So the built gem never distributes diff-lcs. Installed metadata shows a license choice: `["MIT", "Artistic-1.0-Perl", "GPL-2.0-or-later"]`. MIT is available. No code change removes this alert. RSpec requires diff-lcs, and every diff-lcs version uses the same tri-license. This repository has no license-policy scanner config, so there is no code-based place to record an election. Remaining policy decision: a maintainer must elect MIT for diff-lcs. Evidence for that election: the dependency is test-only, it is not distributed in the gem artifact, and MIT is one of the offered licenses.

### Verification
Observed results on this branch (Ruby 3.2.9, local):
- `bundle exec rspec`: 1636 examples, 0 failures.
- Coverage: 96.93% (above the 95% floor).
- `bundle exec rubocop`: 108 files, no offenses.
- `git diff --check`: clean.
- `bundle-audit check`: no vulnerabilities found (ruby-advisory-db updated 2026-08-19).
- `gem build`: success with no warnings. Runtime metadata shows `faraday >= 2.14.3, < 3`, `json ~> 2.19, >= 2.19.9`, and `concurrent-ruby >= 1.3.7, < 2.0`.
- `bundle install --frozen`: succeeds. The lockfile round-trips.
- Bounded Langfuse reachability: the patched Faraday 2.14.3 stack reached the public Langfuse health endpoint (HTTP 200).
- Mermaid rendering was not visually previewed in this environment. The source uses GitHub-supported flowchart syntax.

Unvalidated boundaries:
- Authenticated Langfuse API validation did not run. The `langfuse` agent skill referenced in `AGENTS.md` is not installed in this environment. No Langfuse credentials are set. The SimplePractice staging Langfuse host times out from this runner. So instance-specific validation is blocked. This step is not claimed as passed.
- Local tests ran on Ruby 3.2 only. CI covers Ruby 3.3 and 3.4.
- GitHub Dependabot and code-scanning alert states could not be read directly (API returns 403 for this integration). The findings were confirmed with `bundler-audit` against ruby-advisory-db.

#### `Checklist`
- [ ] Has label
- [x] Has linked issue
- [ ] Tests added for new behavior
- [ ] Docs updated (if user-facing)

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7229389-745c-4edc-8190-e6d29e1fab2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7229389-745c-4edc-8190-e6d29e1fab2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


