### PR TITLE
chore(release): bump version to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-20
+
+### Changed
+- Require Faraday 2.14.3 or newer, dropping Faraday 1.x compatibility (#115).
+
+### Fixed
+- Prevent consumers from resolving vulnerable Faraday, JSON, and concurrent-ruby versions (#115).
+
 ## [0.11.0] - 2026-08-19
 
 > [!NOTE]
@@ -165,7 +173,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated from legacy ingestion API to OTLP endpoint
 - Removed `tracing_enabled` configuration flag (#2)
 
-[Unreleased]: https://github.com/simplepractice/langfuse-rb/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/simplepractice/langfuse-rb/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/simplepractice/langfuse-rb/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/simplepractice/langfuse-rb/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/simplepractice/langfuse-rb/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/simplepractice/langfuse-rb/compare/v0.9.0...v0.10.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    langfuse-rb (0.11.0)
+    langfuse-rb (0.12.0)
       base64 (~> 0.2)
       concurrent-ruby (>= 1.3.7, < 2.0)
       faraday (>= 2.14.3, < 3)

--- a/lib/langfuse/version.rb
+++ b/lib/langfuse/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Langfuse
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end


### PR DESCRIPTION
#### `TL;DR`
<!-- One sentence -->

Prepare `langfuse-rb` 0.12.0 for the merged dependency security fixes and Faraday compatibility change.

#### `Why`
<!-- Motivation/context for this change -->

PR #115 prevents gem consumers from resolving vulnerable Faraday, JSON, and concurrent-ruby versions. It also requires Faraday 2.14.3 or newer and drops Faraday 1.x compatibility. The minor version bump makes that compatibility boundary explicit.

This pull request changes only `CHANGELOG.md`, `Gemfile.lock`, and `lib/langfuse/version.rb`. Tagging and gem building must wait until this pull request merges and its exact commit remains the head of `main`.

Linear: [AAI-401](https://linear.app/simplepractice/issue/AAI-401/release-langfuse-rb-0120)

#### `Checklist`
- [x] Has label
- [x] Has linked issue
- [ ] Tests added for new behavior
- [x] Docs updated (if user-facing)

## Verification

- `make check`: 1,636 examples, 0 failures, 96.93% line coverage; RuboCop inspected 108 files with no offenses.
- `bundle check`: dependencies satisfied.
- Release metadata: version and lockfile report `0.12.0`; changelog comparison links updated; `Unreleased` remains empty.
- `git diff --check`: passed.
- Langfuse CLI authenticated readback: HTTP 200 using credentials loaded directly from `.env`; the core-only query returned one observation.

The gem was not built or published. The release workflow reserves the build for the exact merged release commit, and RubyGems publishing remains a manual MFA-protected step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only (version, lockfile, changelog). No runtime or security-logic changes in this PR.
> 
> **Overview**
> Bumps `langfuse-rb` to **0.12.0** so the Faraday 2.14.3+ requirement and tighter Faraday/JSON/concurrent-ruby constraints from #115 ship as a minor release.
> 
> Updates `Langfuse::VERSION`, `Gemfile.lock`, and changelog comparison links. Documents Faraday 1.x drop and the vulnerable-dependency resolution fix under `[0.12.0]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9b606a4456f5544da3fdfea7e44a6d9ea0f8026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->