### PR TITLE
chore(release): bump version to 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-09-03
+
 ### Fixed
 - Emit Langfuse v4 experiment attributes for local and dataset-backed experiment observations (#118).
 
@@ -176,7 +178,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated from legacy ingestion API to OTLP endpoint
 - Removed `tracing_enabled` configuration flag (#2)
 
-[Unreleased]: https://github.com/simplepractice/langfuse-rb/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/simplepractice/langfuse-rb/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/simplepractice/langfuse-rb/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/simplepractice/langfuse-rb/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/simplepractice/langfuse-rb/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/simplepractice/langfuse-rb/compare/v0.10.0...v0.10.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    langfuse-rb (0.12.0)
+    langfuse-rb (0.12.1)
       base64 (~> 0.2)
       concurrent-ruby (>= 1.3.7, < 2.0)
       faraday (>= 2.14.3, < 3)

--- a/lib/langfuse/version.rb
+++ b/lib/langfuse/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Langfuse
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end


### PR DESCRIPTION
#### `TL;DR`
<!-- One sentence -->
Release langfuse-rb 0.12.1 with complete Langfuse v4 experiment attribution.

#### `Why`
<!-- Motivation/context for this change -->
Version 0.12.0 can ingest experiment traces without making the experiment visible in Langfuse v4. The fix now on `main` emits the required experiment and item attributes, preserves one identity for each run, and applies shared attributes to child observations.

This patch release publishes that backward-compatible correction. It also exposes the resolved experiment ID on the result object and documents the attribution behavior.

#### `Checklist`
- [x] Has label
- [x] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)

#### `Verification`

The complete repository check passed with 1,653 examples, 97.01% line coverage, and no RuboCop offenses. The lockfile resolves the local gem as version `0.12.1`, and the release diff contains only the changelog, lockfile, and version file.

A synthetic local-data experiment ran against Langfuse Cloud from this release branch. Independent Langfuse CLI queries found the experiment and its item. The root and child observations shared the experiment ID, item ID, root observation ID, environment, and release-validation metadata. The item contained the expected input, output, and expected output.

The release tag, gem build, and RubyGems publication are not part of this preparation PR. The tag and gem build will use the exact merged release commit. RubyGems publication remains a manual MFA-protected step.

Closes AAI-449

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only diff (version, lockfile, changelog); no library behavior changes in this PR.
> 
> **Overview**
> This PR **cuts patch release 0.12.1** with no runtime code changes in the diff—only release metadata.
> 
> It bumps `Langfuse::VERSION` to **0.12.1**, updates `Gemfile.lock` to resolve the local gem at that version, and documents the release in **CHANGELOG**: **Fixed** entry for emitting Langfuse v4 experiment attributes on local and dataset-backed experiment observations (#118), dated 2026-09-03, plus updated `[Unreleased]` / `[0.12.1]` compare links.
> 
> The functional fix ships in code already on `main`; this change publishes it as a backward-compatible patch for consumers who need experiment visibility in Langfuse v4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05bc5bdaad12529e4e952ecfbceba7be17783c5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->