### PR TITLE
chore(release): bump version to 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-09-04
+
+### Fixed
+- Forward OTLP exporter metrics to the configured metrics reporter (#117).
+
 ## [0.12.1] - 2026-09-03
 
 ### Fixed
@@ -178,7 +183,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated from legacy ingestion API to OTLP endpoint
 - Removed `tracing_enabled` configuration flag (#2)
 
-[Unreleased]: https://github.com/simplepractice/langfuse-rb/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/simplepractice/langfuse-rb/compare/v0.12.2...HEAD
+[0.12.2]: https://github.com/simplepractice/langfuse-rb/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/simplepractice/langfuse-rb/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/simplepractice/langfuse-rb/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/simplepractice/langfuse-rb/compare/v0.10.1...v0.11.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    langfuse-rb (0.12.1)
+    langfuse-rb (0.12.2)
       base64 (~> 0.2)
       concurrent-ruby (>= 1.3.7, < 2.0)
       faraday (>= 2.14.3, < 3)

--- a/lib/langfuse/version.rb
+++ b/lib/langfuse/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Langfuse
-  VERSION = "0.12.1"
+  VERSION = "0.12.2"
 end


### PR DESCRIPTION
#### `TL;DR`
<!-- One sentence -->
Release langfuse-rb 0.12.2 with the OTLP exporter metrics fix from #117.

#### `Why`
<!-- Motivation/context for this change -->
Version 0.12.1 sends batch processor metrics to the configured reporter but omits OTLP exporter metrics. This patch release publishes the correction already merged into `main`.

The application continues to own its reporter. It flushes and closes the reporter after `Langfuse.shutdown` drains the tracing pipeline.

#### `Checklist`

- [x] Has label
- [x] Has linked issue
- [x] Tests added for new behavior
- [x] Docs updated (if user-facing)

Closes [AAI-466](https://linear.app/simplepractice/issue/AAI-466/release-langfuse-rb-0122)

#### `Verification`

The complete repository check passed with 1,663 examples, 97.01% line coverage, and no RuboCop offenses. The release diff contains only the changelog, lockfile, and version file. Dependency versions are unchanged.

The 0.12.2 SDK exported a synthetic observation on shutdown. Independent Langfuse CLI readback verified its input, output, environment, and release. The documented adapter delivered batch processor and OTLP exporter metrics through a real DogStatsD client over localhost UDP. Langfuse did not flush, close, or shut down the application-owned reporter. Datadog backend ingestion was not tested.

The tag and gem build will use the verified merged release commit. RubyGems publication remains the manual MFA-protected step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version, changelog, and lockfile updates; behavior change is documented from prior merge #117, not introduced in this diff.
> 
> **Overview**
> **Patch release 0.12.2** with no runtime code changes in this diff—only release metadata.
> 
> Updates **`Langfuse::VERSION`** to `0.12.2`, bumps the path gem in **`Gemfile.lock`**, and documents **0.12.2 (2026-09-04)** in **`CHANGELOG.md`**: the shipped fix forwards **OTLP exporter metrics** to the configured metrics reporter (#117), already on `main` since 0.12.1 only covered batch processor metrics. Compare links now point **`[Unreleased]`** at `v0.12.2...HEAD` and add **`[0.12.2]`** for `v0.12.1...v0.12.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03449f81f9008ca2f65471a5ba74d2156fcfdea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->