### PR TITLE
fix: detach root observations from the host application's ambient OpenTelemetry context

### DIFF
--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -631,8 +631,25 @@ module Langfuse
           otel_tracer.start_span(name, start_timestamp: start_time)
         end
       else
-        # Create root span
-        otel_tracer.start_span(name, start_timestamp: start_time)
+        # Create root span, detached from any ambient context.
+        #
+        # `Tracer#start_span` implicitly parents the new span to
+        # `OpenTelemetry::Context.current`, and that context is process-wide and
+        # provider-agnostic. When the host application runs its own instrumentation
+        # (Rack, ActiveJob, Sidekiq...), a root observation started inside an
+        # instrumented request or job would silently become a child of that ambient
+        # span -- even though it belongs to a different TracerProvider that exports
+        # elsewhere. Langfuse then only ingests an orphan child pointing at a
+        # trace_id whose root it never received, and renders it under an empty,
+        # unnamed trace.
+        #
+        # Resetting to `Context::ROOT` for the duration of the span creation keeps
+        # root observations genuinely rooted. Nesting inside the observation is
+        # unaffected: once the span is started it becomes current again, so child
+        # observations keep attaching to it.
+        OpenTelemetry::Context.with_current(OpenTelemetry::Context::ROOT) do
+          otel_tracer.start_span(name, start_timestamp: start_time)
+        end
       end
     end
 

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -643,11 +643,20 @@ module Langfuse
         # trace_id whose root it never received, and renders it under an empty,
         # unnamed trace.
         #
-        # Resetting to `Context::ROOT` for the duration of the span creation keeps
-        # root observations genuinely rooted. Nesting inside the observation is
-        # unaffected: once the span is started it becomes current again, so child
-        # observations keep attaching to it.
-        OpenTelemetry::Context.with_current(OpenTelemetry::Context::ROOT) do
+        # Detaching only the *span* -- rather than resetting to `Context::ROOT` --
+        # keeps root observations genuinely rooted without discarding the rest of
+        # the context. `propagate_attributes` stores user_id, session_id, tags and
+        # metadata as context values, and `SpanProcessor#on_start` reads them from
+        # the parent context; a full reset would silently drop them, so a root
+        # observation opened inside `propagate_attributes` would lose its identity.
+        #
+        # An invalid current span makes the SDK generate a fresh trace_id
+        # (`TracerProvider#internal_start_span` only inherits when the parent span
+        # context is valid). Nesting inside the observation is unaffected: once the
+        # span is started it becomes current again, so child observations keep
+        # attaching to it.
+        root_context = OpenTelemetry::Trace.context_with_span(OpenTelemetry::Trace::Span::INVALID)
+        OpenTelemetry::Context.with_current(root_context) do
           otel_tracer.start_span(name, start_timestamp: start_time)
         end
       end

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -652,14 +652,36 @@ module Langfuse
         #
         # An invalid current span makes the SDK generate a fresh trace_id
         # (`TracerProvider#internal_start_span` only inherits when the parent span
-        # context is valid). Nesting inside the observation is unaffected: once the
-        # span is started it becomes current again, so child observations keep
-        # attaching to it.
+        # context is valid).
+        #
+        # This only applies to *foreign* ambient spans. A Langfuse observation made
+        # current by `observe`/`run_in_context` is a legitimate parent: nested
+        # `Langfuse.observe` calls rely on the ambient context to attach to it, so
+        # detaching there would turn every nested observation into a disconnected
+        # root.
+        return otel_tracer.start_span(name, start_timestamp: start_time) if ambient_langfuse_span?
+
         root_context = OpenTelemetry::Trace.context_with_span(OpenTelemetry::Trace::Span::INVALID)
         OpenTelemetry::Context.with_current(root_context) do
           otel_tracer.start_span(name, start_timestamp: start_time)
         end
       end
+    end
+
+    # Whether the currently active span was created by Langfuse itself.
+    #
+    # Distinguishes "I am nested inside another Langfuse observation" (attach) from
+    # "the host application has an unrelated span open" (detach). Non-recording or
+    # remote spans carry no instrumentation scope and count as foreign, which is the
+    # safe answer: they belong to the caller's trace, not to ours.
+    #
+    # @return [Boolean]
+    def ambient_langfuse_span?
+      span = OpenTelemetry::Trace.current_span
+      return false unless span.context.valid?
+      return false unless span.respond_to?(:instrumentation_scope)
+
+      span.instrumentation_scope&.name == LANGFUSE_TRACER_NAME
     end
 
     # Wraps an OpenTelemetry span in the appropriate observation class

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -751,6 +751,24 @@ RSpec.describe Langfuse do
             .to eq(ambient.context.hex_span_id)
         end
       end
+
+      # Detaching must drop the ambient *span* only. `propagate_attributes` keeps
+      # user_id, session_id, tags and metadata as context values, which
+      # `SpanProcessor#on_start` reads from the parent context -- wiping the whole
+      # context would silently strip identity from every root observation opened
+      # inside the documented `propagate_attributes` pattern.
+      it "keeps propagated attributes on a root observation" do
+        with_ambient_span do
+          described_class.propagate_attributes(user_id: "user_123", session_id: "session_456") do
+            root = described_class.start_observation("root", {})
+            attrs = root.otel_span.attributes
+
+            expect(attrs["user.id"]).to eq("user_123")
+            expect(attrs["session.id"]).to eq("session_456")
+            root.end
+          end
+        end
+      end
     end
   end
 

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -712,6 +712,46 @@ RSpec.describe Langfuse do
         end.to raise_error(ArgumentError, /Invalid trace_id/)
       end
     end
+
+    context "when the host application has an ambient span from another provider" do
+      # Host apps commonly enable their own OpenTelemetry auto-instrumentation
+      # (Rack, ActiveJob...) on a separate TracerProvider exported elsewhere.
+      # `OpenTelemetry::Context` is process-wide and provider-agnostic, so a root
+      # observation must explicitly detach from it -- otherwise it silently becomes
+      # a child of a span Langfuse never ingests, and shows up under an empty trace.
+      def with_ambient_span(&block)
+        provider = OpenTelemetry::SDK::Trace::TracerProvider.new
+        provider.tracer("host-app").in_span("GET /orders", &block)
+      ensure
+        provider&.shutdown(timeout: 1)
+      end
+
+      it "starts a root observation on its own trace, not the ambient one" do
+        with_ambient_span do |ambient|
+          observation = described_class.start_observation("root", {})
+
+          expect(observation.trace_id).not_to eq(ambient.context.hex_trace_id)
+        end
+      end
+
+      it "still nests child observations under the root observation" do
+        with_ambient_span do
+          root = described_class.start_observation("root", {})
+          child = root.start_observation("child")
+
+          expect(child.trace_id).to eq(root.trace_id)
+        end
+      end
+
+      it "restores the ambient context once the root observation is started" do
+        with_ambient_span do |ambient|
+          described_class.start_observation("root", {})
+
+          expect(OpenTelemetry::Trace.current_span.context.hex_span_id)
+            .to eq(ambient.context.hex_span_id)
+        end
+      end
+    end
   end
 
   describe ".observe" do

--- a/spec/langfuse_spec.rb
+++ b/spec/langfuse_spec.rb
@@ -757,6 +757,21 @@ RSpec.describe Langfuse do
       # `SpanProcessor#on_start` reads from the parent context -- wiping the whole
       # context would silently strip identity from every root observation opened
       # inside the documented `propagate_attributes` pattern.
+      # Detaching must not apply to Langfuse's own spans: `observe` makes its
+      # observation the current span, and nested `Langfuse.observe` /
+      # `start_observation` calls rely on that ambient context to attach. Detaching
+      # there would export every nested observation as a disconnected root.
+      it "still attaches a nested observation to the enclosing Langfuse observation" do
+        with_ambient_span do
+          described_class.observe("parent") do |parent|
+            nested = described_class.start_observation("nested", {})
+
+            expect(nested.trace_id).to eq(parent.trace_id)
+            nested.end
+          end
+        end
+      end
+
       it "keeps propagated attributes on a root observation" do
         with_ambient_span do
           described_class.propagate_attributes(user_id: "user_123", session_id: "session_456") do


### PR DESCRIPTION
## Problem

`create_otel_span` creates root observations with:

```ruby
else
  # Create root span
  otel_tracer.start_span(name, start_timestamp: start_time)
end
```

`Tracer#start_span` implicitly parents the new span to `OpenTelemetry::Context.current`. That context is **process-wide and provider-agnostic** — it is not scoped to the `TracerProvider` the tracer came from. So this branch only produces an actual root span when nothing else is currently active.

In a host application that runs its own OpenTelemetry instrumentation (Rack, ActiveJob, Sidekiq…) on a separate provider — a very common setup — a root observation started inside an instrumented request or job silently becomes a **child of that ambient span**.

The consequence is only visible on the Langfuse side: Langfuse ingests the child, whose `trace_id` belongs to a root span that was exported to the application's own backend and never reaches Langfuse. The UI then renders an empty, unnamed trace wrapping the real observation. Grouping or filtering by trace name becomes unusable, since a large share of traces have no name at all.

This is distinct from the isolated tracer provider introduced in 0.8.0 (#77): that change isolates which spans are **exported** to Langfuse (and it works — thank you for it). This issue is about which span a new span is **parented to**, which context propagation decides independently of the provider.

## Fix

Reset to `OpenTelemetry::Context::ROOT` for the duration of the root span creation only:

```ruby
OpenTelemetry::Context.with_current(OpenTelemetry::Context::ROOT) do
  otel_tracer.start_span(name, start_timestamp: start_time)
end
```

Nesting is deliberately unaffected: once the span is started it becomes current again, so child observations keep attaching to it, and the caller's ambient context is restored on the way out. The child branch is untouched.

## Tests

Three specs under `.start_observation`, covering the fix and the two properties a naive fix would break:

- a root observation gets its own trace, not the ambient one (**fails on `main`**, passes with the change);
- child observations still nest under the root;
- the caller's ambient context is restored afterwards.

`bundle exec rspec spec/langfuse_spec.rb` → 100 examples, 0 failures. `rubocop` clean on both changed files.

Happy to adjust naming, comment length or spec placement to your preferences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core root-span parenting in mixed OpenTelemetry setups; incorrect detection of “foreign” vs Langfuse ambient spans could mis-nest traces, though the scope check and new specs narrow the blast radius.
> 
> **Overview**
> Fixes root Langfuse observations being **parented to the host app’s unrelated OpenTelemetry span** when Rack/ActiveJob/Sidekiq (or another provider) already has `Context.current` set. Those roots showed up in Langfuse as orphan children under **empty, unnamed traces**.
> 
> Root span creation in `create_otel_span` now **temporarily clears only the active span** (invalid span in context) before `start_span`, so a new trace_id is generated without wiping `propagate_attributes` context values. If the ambient span is **Langfuse’s own** (`ambient_langfuse_span?` via tracer instrumentation scope), behavior is unchanged so nested `observe` / `start_observation` calls still attach.
> 
> Adds specs for a foreign ambient span: own trace_id, nested children, restored caller context, nested Langfuse observations, and propagated `user.id` / `session.id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 259943e383908db7dcc92768bb56121f1ec9c33b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->